### PR TITLE
Adding generic parameter evaluation

### DIFF
--- a/benchmark/index.html
+++ b/benchmark/index.html
@@ -74,7 +74,7 @@
 
     <script src="../vendor/jquery.min.js"></script>
     <script src="uubench.js"></script>
-    <script src="../dist/dust-full-0.2.5.min.js"></script>
+    <script src="../dist/dust-full-0.4.0.js"></script>
     <script src="suites/dust_suite.js"></script>
     <script src="suites/mustache_suite.js"></script>
     <script src="suites/handlebars_suite.js"></script>

--- a/benchmark/suites/dust_suite.js
+++ b/benchmark/suites/dust_suite.js
@@ -90,6 +90,20 @@ var benches = {
                  {name: "blue", current: false, url: "#Blue"}
                ]
              }
+  },
+
+  "if": {
+    source:  "{@if cond=\"{a} + {b} == 3 && 'U{{{a} * {b}}}' == 'U2'\"}\n" +
+             "  Condition is true\n"                                     +
+             "{:else}\n"                                                 +
+             "  Condition is false\n"                                    +
+             "{/if}",
+    context: {
+               a: 1,
+               b: function () {
+                  return 2;
+               }
+             }
   }
 
 }

--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -14,32 +14,18 @@ var helpers = {
   },
   
   "if": function( chunk, context, bodies, params ){
-    var cond = ( params.cond );
-    
-    if( params && params.cond ){
-      // resolve dust references in the expression
-      if( typeof cond === "function" ){
-        cond = '';
-        chunk.tap( function( data ){
-          cond += data;
-          return '';
-        } ).render( params.cond, context ).untap();
-        if( cond === '' ){
-          cond = false;
-        }
+    if (params && params.cond) {
+      var cond = dust.resolve("cond", chunk, context, bodies, params),
+        test = new Function("chunk", "context", "bodies", "params", "return " + cond);
+      if (test()) {
+        return chunk.render(bodies.block, context);
       }
-      // eval expressions with no dust references
-      if( eval( cond ) ){
-       return chunk.render( bodies.block, context );
-      } 
-      if( bodies['else'] ){
-       return chunk.render( bodies['else'], context );
+      if (bodies['else']) {
+        return chunk.render(bodies['else'], context);
       }
-    } 
-    // no condition
-    else {
-      if( window.console ){
-        window.console.log( "No expression given!" );
+    } else {
+      if (window.console) {
+        window.console.log("dust.helpers.if: no expression given");
       }
     }
     return chunk;
@@ -47,5 +33,46 @@ var helpers = {
 };
 
 dust.helpers = helpers;
+
+dust.resolve = function (name, chunk, context, bodies, params) {
+  var output = "", pending = false, code = "", exec;
+  if (params && params[name]) {
+    if (typeof params[name] === "function") {
+      chunk.tap(function (data) {
+        data += "";
+        var leftIndex = data.indexOf("{{"), rightIndex = data.indexOf("}}");
+        if (leftIndex >= 0 || rightIndex >= 0) {
+          if (leftIndex >= 0) {
+            output += data.substring(0, leftIndex);
+            pending = true;
+          }
+          if (rightIndex >= 0) {
+            if (rightIndex > 0) {
+              code += data.substring(leftIndex + 2, rightIndex);
+            }
+            exec = new Function("chunk", "context", "bodies", "params", "return " + code);
+            output += exec(chunk, context, bodies, params);
+            code = "";
+            pending = false;
+
+            output += data.substring(rightIndex + 2);
+          } else {
+            code += data.substring(leftIndex + 2);
+          }
+        } else {
+          if (pending) {
+            code += data;
+          } else {
+            output += data;
+          }
+        }
+        return "";
+      }).render(params[name], context).untap();
+    } else {
+      output = params[name];
+    }
+  }
+  return output;
+};
 
 })(typeof exports !== 'undefined' ? exports : window.dust);


### PR DESCRIPTION
As discussed in the issue : https://github.com/linkedin/dustjs/issues/19

Added dust.resolve as a generic solution to parsing and evaluating parameters in helpers. Renders {name} as dust normally does and evaluates {{code}} as javascript (using Function).

@if helper now uses dust.resolve to parse the cond parameter. Similar performance in Chrome, huge improvement in Firefox.

First pull request ! Hope i'm doing it right :)

Example:

``` javascript
   dust.helpers["Lang"] = function(chunk, context, bodies, params) {
        var key = dust.resolve("key", chunk, context, bodies, params);
        if (Object.keys(params).length > 1) {
            var data = {};
            for (var name in params) {
                if (name != "key") {
                    data[name] = dust.resolve(name, chunk, context, bodies, params);
                }
            }
            chunk.write(Lang.get(key, data));
        } else {
            chunk.write(Lang.get(key));
        }

        return chunk;
    };

    In your template: {@Lang key="items.type.{type}" quantity="{{{quantity} * 3}}"/}
```
