### PR TITLE
process.nextTick instead of setTimeout

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -67,9 +67,15 @@ if (Array.isArray) {
   };
 }
 
-dust.nextTick = function(callback) {
-  setTimeout(callback, 0);
-}
+dust.nextTick = (function() {
+  if (process) {
+    return process.nextTick;
+  } else {
+    return function(callback) {
+      setTimeout(callback,0);
+    }
+  }
+} )();
 
 dust.isEmpty = function(value) {
   if (dust.isArray(value) && !value.length) return true;
@@ -99,7 +105,7 @@ dust.filters = {
   j: function(value) { return dust.escapeJs(value); },
   u: encodeURI,
   uc: encodeURIComponent
-}
+};
 
 function Context(stack, global, blocks) {
   this.stack  = stack;
@@ -109,14 +115,14 @@ function Context(stack, global, blocks) {
 
 dust.makeBase = function(global) {
   return new Context(new Stack(), global);
-}
+};
 
 Context.wrap = function(context) {
   if (context instanceof Context) {
     return context;
   }
   return new Context(new Stack(context));
-}
+};
 
 Context.prototype.get = function(key) {
   var ctx = this.stack, value;
@@ -175,7 +181,7 @@ Context.prototype.getBlock = function(key) {
     fn = blocks[len][key];
     if (fn) return fn;
   }
-}
+};
 
 Context.prototype.shiftBlocks = function(locals) {
   var blocks = this.blocks;
@@ -189,7 +195,7 @@ Context.prototype.shiftBlocks = function(locals) {
     return new Context(this.stack, this.global, newBlocks);
   }
   return this;
-}
+};
 
 function Stack(head, tail, idx, len) {
   this.tail = tail;
@@ -222,7 +228,7 @@ Stub.prototype.flush = function() {
     this.head = chunk;
   }
   this.callback(null, this.out);
-}
+};
 
 function Stream() {
   this.head = new Chunk(this);
@@ -245,7 +251,7 @@ Stream.prototype.flush = function() {
     this.head = chunk;
   }
   this.emit('end');
-}
+};
 
 Stream.prototype.emit = function(type, data) {
   var events = this.events;
@@ -253,7 +259,7 @@ Stream.prototype.emit = function(type, data) {
   if (events && events[type]) {
     events[type](data);
   }
-}
+};
 
 Stream.prototype.on = function(type, callback) {
   if (!this.events) {
@@ -261,7 +267,7 @@ Stream.prototype.on = function(type, callback) {
   }
   this.events[type] = callback;
   return this;
-}
+};
 
 function Chunk(root, next, taps) {
   this.root = root;
@@ -279,7 +285,7 @@ Chunk.prototype.write = function(data) {
   }
   this.data += data;
   return this;
-}
+};
 
 Chunk.prototype.end = function(data) {
   if (data) {
@@ -288,7 +294,7 @@ Chunk.prototype.end = function(data) {
   this.flushable = true;
   this.root.flush();
   return this;
-}
+};
 
 Chunk.prototype.map = function(callback) {
   var cursor = new Chunk(this.root, this.next, this.taps),
@@ -298,7 +304,7 @@ Chunk.prototype.map = function(callback) {
   this.flushable = true;
   callback(branch);
   return cursor;
-}
+};
 
 Chunk.prototype.tap = function(tap) {
   var taps = this.taps;
@@ -309,16 +315,16 @@ Chunk.prototype.tap = function(tap) {
     this.taps = new Tap(tap);
   }
   return this;
-}
+};
 
 Chunk.prototype.untap = function() {
   this.taps = this.taps.tail;
   return this;
-}
+};
 
 Chunk.prototype.render = function(body, context) {
   return body(this, context);
-}
+};
 
 Chunk.prototype.reference = function(elem, context, auto, filters) {
   if (typeof elem === "function") {
@@ -377,7 +383,7 @@ Chunk.prototype.exists = function(elem, context, bodies) {
     return skip(this, context);
   }
   return this;
-}
+};
 
 Chunk.prototype.notexists = function(elem, context, bodies) {
   var body = bodies.block,
@@ -389,7 +395,7 @@ Chunk.prototype.notexists = function(elem, context, bodies) {
     return skip(this, context);
   }
   return this;
-}
+};
 
 Chunk.prototype.block = function(elem, context, bodies) {
   var body = bodies.block;


### PR DESCRIPTION
using process.nextTick if the underlying platform is node as it is more performant than setTimeout( callback, 0)
