### PR TITLE
preventing dust to crash on non existant if-condition

### DIFF
--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -3,7 +3,7 @@
 function isSelect(context) {
   var value = context.current();
   return typeof value === "object" && value.isSelect === true;    
-};
+}
 
 function filter(chunk, context, bodies, params, filter) {
   var params = params || {},
@@ -31,7 +31,7 @@ function filter(chunk, context, bodies, params, filter) {
   }
 
   return chunk.write('');
-};
+}
 
 function coerce (value, type, context) {
   if (value) {
@@ -45,7 +45,7 @@ function coerce (value, type, context) {
   }
 
   return value;
-};
+}
 
 var helpers = {
   
@@ -59,11 +59,11 @@ var helpers = {
   idx: function(chunk, context, bodies) {
     return bodies.block(chunk, context.push(context.stack.index));
   },
-  
+
   "if": function( chunk, context, bodies, params ){
-    var cond = ( params.cond );
-    
     if( params && params.cond ){
+      var cond = params.cond;
+
       // resolve dust references in the expression
       if( typeof cond === "function" ){
         cond = '';
@@ -78,14 +78,14 @@ var helpers = {
       // eval expressions with no dust references
       if( eval( cond ) ){
        return chunk.render( bodies.block, context );
-      } 
+      }
       if( bodies['else'] ){
        return chunk.render( bodies['else'], context );
       }
-    } 
+    }
     // no condition
     else {
-      if( window.console ){
+      if( typeof window !== 'undefined' && window.console ){
         window.console.log( "No expression given!" );
       }
     }


### PR DESCRIPTION
if no condition has been specified in the template, the if-helper would crash.
also without checking the existence of 'window' in the node-environment the helper would fail.
