### PR TITLE
make `tap` helper work with function-valued context variables; add tests

### DIFF
--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -2,7 +2,7 @@
 
 /* make a safe version of console if it is not available
  * currently supporting:
- *   _console.log 
+ *   _console.log
  * */
 var _console = (typeof console !== 'undefined')? console: {
   log: function(){
@@ -12,12 +12,12 @@ var _console = (typeof console !== 'undefined')? console: {
 
 function isSelect(context) {
   var value = context.current();
-  return typeof value === "object" && value.isSelect === true;    
+  return typeof value === "object" && value.isSelect === true;
 }
 
 function filter(chunk, context, bodies, params, filter) {
   var params = params || {},
-      actual, 
+      actual,
       expected;
   if (params.key) {
     actual = helpers.tap(params.key, chunk, context);
@@ -57,7 +57,7 @@ function coerce (value, type, context) {
 }
 
 var helpers = {
-  
+
   sep: function(chunk, context, bodies) {
     if (context.stack.index === context.stack.of - 1) {
       return chunk;
@@ -68,32 +68,36 @@ var helpers = {
   idx: function(chunk, context, bodies) {
     return bodies.block(chunk, context.push(context.stack.index));
   },
-  
+
   contextDump: function(chunk, context, bodies) {
     _console.log(JSON.stringify(context.stack));
     return chunk;
   },
-  
+
   // Utility helping to resolve dust references in the given chunk
   tap: function( input, chunk, context ){
     // return given input if there is no dust reference to resolve
     var output = input;
     // dust compiles a string to function, if there are references
     if( typeof input === "function"){
-      output = '';
-      chunk.tap(function(data){
-        output += data;
-        return '';
-      }).render(input, context).untap();
-      if( output === '' ){
-        output = false;
+      if( input.length == 0 ) { // just a plain function, not a dust `body` function
+        output = input();
+      } else {
+        output = '';
+        chunk.tap(function(data){
+          output += data;
+          return '';
+        }).render(input, context).untap();
+        if( output === '' ){
+          output = false;
+        }
       }
-    } 
+    }
     return output;
   },
 
   /**
-  if helper 
+  if helper
    @param cond, either a string literal value or a dust reference
                 a string literal value, is enclosed in double quotes, e.g. cond="2>3"
                 a dust reference is also enclosed in double quotes, e.g. cond="'{val}'' > 3"
@@ -118,9 +122,9 @@ var helpers = {
     }
     return chunk;
   },
-  
+
    /**
-   select/eq/lt/lte/gt/gte/default helper 
+   select/eq/lt/lte/gt/gte/default helper
    @param key, either a string literal value or a dust reference
                 a string literal value, is enclosed in double quotes, e.g. key="foo"
                 a dust reference may or may not be enclosed in double quotes, e.g. key="{val}" and key=val are both valid

--- a/test/core.js
+++ b/test/core.js
@@ -80,6 +80,187 @@ exports.coreSetup = function(suite, auto) {
       }
     })
   });
+
+  suite.test("tap (plain text string literal)", function() {
+    var unit = this;
+    dust.helpers.tapper = function(chunk, context, bodies, params) {
+      var result = dust.helpers.tap(params.value,chunk,context);
+      chunk.write(result);
+      return chunk;
+    };
+    var base_context = { };
+    dust.renderSource("plain text. {@tapper value=\"plain text\"/}", base_context, function(err, out) {
+      try {
+        unit.ifError(err);
+        unit.equals(out, "plain text. plain text");
+      } catch(err) {
+        unit.fail(err);
+        return;
+      }
+      unit.pass();
+    });
+  });
+
+  suite.test("tap (string literal that includes a string-valued {context variable})", function() {
+    var unit = this;
+    dust.helpers.tapper = function(chunk, context, bodies, params) {
+      var result = dust.helpers.tap(params.value,chunk,context);
+      chunk.write(result);
+      return chunk;
+    };
+    var base_context = { a:"Alpha" };
+    dust.renderSource("a is {a}. {@tapper value=\"a is {a}\"/}", base_context, function(err, out) {
+      try {
+        unit.ifError(err);
+            unit.equals(out, "a is Alpha. a is Alpha");
+      } catch(err) {
+        unit.fail(err);
+        return;
+      }
+      unit.pass();
+    });
+  });
+
+  suite.test("tap (reference to string-valued context variable)", function() {
+    var unit = this;
+    dust.helpers.tapper = function(chunk, context, bodies, params) {
+      var result = dust.helpers.tap(params.value,chunk,context);
+      chunk.write(result);
+      return chunk;
+    };
+    var base_context = { a:"Alpha" };
+    dust.renderSource("{a}. {@tapper value=a/}", base_context, function(err, out) {
+      try {
+        unit.ifError(err);
+            unit.equals(out, "Alpha. Alpha");
+      } catch(err) {
+        unit.fail(err);
+        return;
+      }
+      unit.pass();
+    });
+  });
+
+  suite.test("tap (string literal that includes a string-valued {context function})", function() {
+    var unit = this;
+    dust.helpers.tapper = function(chunk, context, bodies, params) {
+      var result = dust.helpers.tap(params.value,chunk,context);
+      chunk.write(result);
+      return chunk;
+    };
+    var base_context = { "b":function() { return "beta"; } };
+    dust.renderSource("b is {b}. {@tapper value=\"b is {b}\"/}", base_context, function(err, out) {
+      try {
+        unit.ifError(err);
+            unit.equals(out, "b is beta. b is beta");
+      } catch(err) {
+        unit.fail(err);
+        return;
+      }
+      unit.pass();
+    });
+  });
+
+  suite.test("tap (reference to a a string-valued {context function})", function() {
+    var unit = this;
+    dust.helpers.tapper = function(chunk, context, bodies, params) {
+      var result = dust.helpers.tap(params.value,chunk,context);
+      chunk.write(result);
+      return chunk;
+    };
+    var base_context = { "b":function() { return "beta"; } };
+    dust.renderSource("{b}. {@tapper value=b/}", base_context, function(err, out) {
+      try {
+        unit.ifError(err);
+            unit.equals(out, "beta. beta");
+      } catch(err) {
+        unit.fail(err);
+        return;
+      }
+      unit.pass();
+    });
+  });
+
+  suite.test("tap (string literal that includes an object-valued {context variable})", function() {
+    var unit = this;
+    dust.helpers.tapper = function(chunk, context, bodies, params) {
+      var result = dust.helpers.tap(params.value,chunk,context);
+      chunk.write(result);
+      return chunk;
+    };
+    var base_context = { "a":{"foo":"bar"} };
+    dust.renderSource("a.foo is {a.foo}. {@tapper value=\"a.foo is {a.foo}\"/}", base_context, function(err, out) {
+      try {
+        unit.ifError(err);
+            unit.equals(out, "a.foo is bar. a.foo is bar");
+      } catch(err) {
+        unit.fail(err);
+        return;
+      }
+      unit.pass();
+    });
+  });
+
+  suite.test("tap (reference to an object-valued {context variable})", function() {
+    var unit = this;
+    dust.helpers.tapper = function(chunk, context, bodies, params) {
+      var result = dust.helpers.tap(params.value,chunk,context);
+      chunk.write(result);
+      return chunk;
+    };
+    var base_context = { "a":{"foo":"bar"} };
+    dust.renderSource("{a.foo}. {@tapper value=a.foo/}", base_context, function(err, out) {
+      try {
+        unit.ifError(err);
+            unit.equals(out, "bar. bar");
+      } catch(err) {
+        unit.fail(err);
+        return;
+      }
+      unit.pass();
+    });
+  });
+
+  suite.test("tap (string literal that calls a function within an object-valued {context variable})", function() {
+    var unit = this;
+    dust.helpers.tapper = function(chunk, context, bodies, params) {
+      var result = dust.helpers.tap(params.value,chunk,context);
+      chunk.write(result);
+      return chunk;
+    };
+    var base_context = { "a": {"foo":function() { return "bar"; } } };
+    dust.renderSource("a.foo is {a.foo}. {@tapper value=\"a.foo is {a.foo}\"/}", base_context, function(err, out) {
+      try {
+        unit.ifError(err);
+        unit.equals(out, "a.foo is bar. a.foo is bar");
+      } catch(err) {
+        unit.fail(err);
+        return;
+      }
+      unit.pass();
+    });
+  });
+
+  suite.test("tap (reference to a function within an object-valued {context variable})", function() {
+    var unit = this;
+    dust.helpers.tapper = function(chunk, context, bodies, params) {
+      var result = dust.helpers.tap(params.value,chunk,context);
+      chunk.write(result);
+      return chunk;
+    };
+    var base_context = { "a": {"foo":function() { return "bar"; } } };
+    dust.renderSource("{a.foo} {@tapper value=a.foo/}", base_context, function(err, out) {
+      try {
+        unit.ifError(err);
+            unit.equals(out, "bar bar");
+      } catch(err) {
+        unit.fail(err);
+        return;
+      }
+      unit.pass();
+    });
+  });
+
 }
 
 function testRender(unit, source, context, expected, error) {


### PR DESCRIPTION
This pull request addresses a problem with the `tap` function recently added to dust-helpers.js.

Tap doesn't always work properly when it encounters references to context keys that resolve to _functions_ as opposed to scalar values.

For instance, given a base context object that includes a _function_:

```
    { foo: function() { return "bar"; } }
```

Dust will generally resolve a reference to `foo` by evaluating the function.  I.e.  the template `{foo}` will resolve to `bar`.

In some circumstances the `tap` function doesn't quite do that--yielding an error or a blank/undefined value.

Specifically, suppose we're creating a helper function named `example` that accepts an inline-parameter named `value`.  We'd like to use the `tap` helper function (helper-helper-function?) to allow `example` to handle things like:

```
    {@example value="a literal string"/}

    {@example value=an_object_reference/}

    {@example value="a literal string containing {an_object_reference}"/}

    etc. 
```

in a dust-like way.But while tap works as expected for

```
    {@example value=an_object_reference/}
```

when `an_object_reference` resolves to a _string_, it gives an error with `an_object_reference` resolves to a JavaScript _function_.

The underlying cause for this is that the `tap` method uses `typeof input === 'function'` to identify the input values that need to be "rendered" with dust, but not every input function is a dust `body`-style function.

The change in this pull request is to check to see if `input` is a zero-argument function, in which case `tap` evaluates the function (i.e. `output = input()`) rather than trying to tap and render it as a dust template.

Unit tests for several `tap` cases are included in the patch.
