### PR TITLE
Updated README for consistency and readability

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,56 +1,63 @@
 Dust core unit-tests
 ------------------------
-core tests run on node, use the following command
+In the current distribution of dust, we have unit tests in jasmine for both the client and the nodejs version.
+If you want to run the node.js version, use the following command:
 
      node test/server.js
 
 Dust unit-tests using jasmine
 -----------------------------
-
-In the current distribution of dust, we have unit tests in jasmine for both the client and the nodejs version.
-If you want to run the client version just open the html page called specRunner.html located in
+If you want to run the client version just open the html page called specRunner.html located in:
  
      test/jasmine-test/client/specRunner.html
 
-Pre-requisites for tests on node server version: 
-----------------------------------
+**Note:** Unlike the node.js version, the browser version needs pre-compiled distribution files to run. If you made local changes to your dust code, use the `make` command to run tests _(see below)_.
+
+Running tests on node server version 
+------------------------------------
 * install nodejs 0.6 or greater 
 * install npm
-* install jasmine test framework : npm install -g jasmine-node
+* install testing dependencies by running in the package directory:
 
-In order to run the node.js version of dust, run this command in the terminal
+         npm install
 
-     node test/jasmine-test/server/specRunner.js
+* and then run this command in the terminal
+
+         node test/jasmine-test/server/specRunner.js
 
 
-Run tests with make
--------------------
-  * core unit tests: 
-       make test
+Running tests with make
+-----------------------
+* core unit tests:
 
-  * jasmine unit test
-       make jasmine
+        make test
 
-Note: the above commands has to be run in the project root folder.
+* jasmine unit test:
 
-Code coverage report
------------------------------
+        make jasmine
 
-We are using a tool called node-cover, it can be installed by npm with the following command:
+**Note:** the above commands has to be run in the project root folder.
 
-     npm install cover -g
 
-Once you have installed cover, you can use it to generate the code coverage results
+Running code coverage report
+----------------------------
 
-Run Cover
--------------- 
+* follow the node server test instructions above to install dependencies
+* install our coverage tool called node-cover using npm:
 
-      cover run test/jasmine-test/server/specRunner.js // runs all the test and creates a folder with results.
-   
-      cover report // shows you a table with % code covered, missed lines, #lines, %blocks, missed blocks and # blocks.
+        npm install cover -g
 
-      cover report html //creates a folder the location where you run the command and the report is in html.
+* you can now use it to generate the code coverage results:
+  * run all the test and create a folder with results:
+
+            cover run test/jasmine-test/server/specRunner.js
+
+  * show a table with % code covered, missed lines, #lines, %blocks, missed blocks and # blocks:
+
+            cover report
+
+  * create a folder the location where you run the command and the report is in html:
+
+            cover report html
 
 Cover creates one html file per js file used by the test. The lines that are not covered are shown on red.
-
-


### PR DESCRIPTION
I've updated the test README a bit since I was struggling with getting started with tests. The formatting on Github was quite broken. I feel the README still needs some work, but I need some guidance, so here are questions for discussion:
- "Dust core unit-tests" vs "Dust unit-tests using jasmine"
  Are these running the same test suite, only one in node and the other in browser via jasmine? Or do the suites differ in content? (Misleading that one is called "core unit-tests" and the other "unit tests using jasmine"
- `node test/server.js` vs `node test/jasmine-test/server/specRunner.js` vs `make test` vs `make jasmine`
  What is the difference between these two styles of calling node.js tests? Does one cover just core and the other full test suite? Are they identical? Why list all four?!
- can we move cover to Makefile aswell?
  Reason: the recommended node.js practice is NOT to install global packages for project-specific development. Since `cover` is already listed as a dependency and thus installed via `npm install`, you can already run it via `./node_modules/.bin/cover` - and there's no need installing it again into global namespace. However, the path is a bit cumbersome, so I propose making `make cover` and `make cover-help` or just dropping these intructions in favour of existing umbrella `make coverage` (but fixing the path to be local).
- finally an almost identical README is duplicated in linkedin/dust-helpers - could the helpers perhaps just point to this README? Keeping them synchronized will be annoying.
