### PR TITLE
add preserve new lines filter

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -108,6 +108,7 @@ dust.filter = function(string, auto, filters) {
 
 dust.filters = {
   h: function(value) { return dust.escapeHtml(value); },
+  pn: function(value) { return dust.preserveNewLines(value); },
   j: function(value) { return dust.escapeJs(value); },
   u: encodeURI,
   uc: encodeURIComponent,
@@ -527,6 +528,13 @@ dust.escapeHtml = function(s) {
       return s;
     }
     return s.replace(AMP,'&amp;').replace(LT,'&lt;').replace(GT,'&gt;').replace(QUOT,'&quot;').replace(SQUOT, '&#39;');
+  }
+  return s;
+};
+    
+dust.preserveNewLines = function(s) {
+  if (typeof s === "string") {
+    return s.replace(/\r\n/g, "\n").replace(/\n/g, "<br/>");
   }
   return s;
 };

--- a/test/jasmine-test/spec/grammarTests.js
+++ b/test/jasmine-test/spec/grammarTests.js
@@ -569,6 +569,13 @@ var grammarTests = [
               },
     expected: "Hello Foo Bar World!",
     message: "should test scope of context function"
+  },
+  {
+    name:     "preserve new lines",
+    source:   "{text_with_new_lines|s|h|pn}{~n}{text_with_new_lines}",
+    context:  { text_with_new_lines: "Hello\nWorld!\nHello\r\nWorld!" },
+    expected: "Hello<br/>World!<br/>Hello<br/>World!\nHello\nWorld!\nHello\r\nWorld!",
+    message: "should convert new lines to <br/>"
   }
 ];
 


### PR DESCRIPTION
I need to preserve new lines in users' comments. I've added a filter for that. It's a bit tricky to use though.
{text|s|h|pn}
where "s" is needed to disable the automatic html escaping and force the correct sequence of "h" (html escape) and "pn" (preserve new lines, i.e. convert \r\n and \n to &lt;br/&gt;)
