### PR TITLE
cover, uglify and jasmine move to dev dependencies. GH-183

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/linkedin/dustjs.git"
   },
   "keywords": ["templates", "views"],
-  "dependencies": {
+    "devDependencies": {
     "jasmine-node"   :  "1.0.x",
     "cover"          :  "0.2.x",
     "uglify-js"      :  "1.3.3"


### PR DESCRIPTION
note that now you should use: npm install --dev to install the dev dependencies.
The npm install command will not install jasmine, cover or uglify.
