### PR TITLE
Security update for lib/dust.js

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -633,7 +633,7 @@ dust.encodeURIComponent = function() {
 	return encodeURIComponent.apply(this, arguments).replace(/[!'()]/g, escape).replace(/\*/g, '%2A');
 };
 
-// TODO: use config for this or localStorage value
+// TODO: use config for this or localStorage value dust.escapeHtml(dust.escapeJs("O'Connor")) is O\&#39;Connor
 dust.backwardCompatibility = true;
 
 dust.escapeHtml = (function(backwardCompatibility, undefined) {


### PR DESCRIPTION
Add few more characters to escapeJs, escapeHtml and JSON.stringify to prevent XSS attacks if developer use wrong encode context or use only one escape function if need 2 or more.
Little bit changed, now escapeJs don't encode chars \u007f-\uffff except \u2028\u2029 which can break inline javascript strings.
