### PR TITLE
Security update for lib/dust.js

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -713,7 +713,7 @@ dust.escapeJs = (function(backwardCompatibility, undefined) {
 	// TODO: remove it after default encoding for script context <script>var x = '{x|j}'</script> fixed
 	if (backwardCompatibility) {
 		index['<'] = '<';
-		index['\''] = '\\\'';
+	//	index['\''] = '\\\''; // not compatible with JSON.parse
 		index['"'] = '\\"';
 		index['&'] = '&';
 	}


### PR DESCRIPTION
dust.backwardCompatibility
1. dust.backwardCompatibility special variable for if it's true \ not encoded in HTML and <'"& not encoded in JS just backspaced \' and \"
2. We don't override JSON.stringify I just use dust.JSONstringify for js flag
   dust.JSONstringify({'test':'<script>alert(\'1\')</script>'})
   with backwardCompatibility is {"test":"<script\u003ealert\u0028\'1\'\u0029<\u002fscript\u003e"}
3. I added dust.sanitizeURI function with flag url (for example value='javascript:alert(1)'; {value|url|s} will be ./javascript:alert%281%29) you can use it with any valid url
4. I changed uc with dust.encodeURIComponent (with encoding of '()!*)
5. escapeHtml and escapeJs the same (except dust.backwardCompatibility, it additionally encode symbols like ()[]{}= etc. and replace some control chars)
