### PR TITLE
AMD friendly module pattern

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -23,6 +23,7 @@
 
   var dust = {};
   dust.cache = {};
+  dust.helpers = {};
 
   dust.register = function(name, tmpl) {
     if (!name) return;


### PR DESCRIPTION
Making `dust` AMD friendly. 
Using the UMD pattern https://github.com/umdjs/umd/blob/master/returnExports.js

Top part handles all the different cases for AMD/CommonJS and falls back to the window global

Biggest changes: 
- remove the `getGlobal` method in favor of the passing the global this into the closure
- remove the export check and use the UMD pattern check (but I've kept the node server check in the module)
- set the `dust.helpers` object here (line 26)
