### PR TITLE
Security update for lib/dust.js

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -683,8 +683,8 @@ dust.escapeHtml = (function(backwardCompatibility, undefined) {
 		if (backwardCompatibility === 2) { // please fix unit tests!
 			index['['] = '[';	
 			index[']'] = ']';
-			index['('] = '[';	
-			index[')'] = ']';	
+			index['('] = '(';	
+			index[')'] = ')';	
 			index['/'] = '/';	
 			index['.'] = '.';	
 			index[','] = ',';	


### PR DESCRIPTION
dust.backwardCompatibility = 2; // unit tests compatible
// localStorage.setItem('dust.backwardCompatibility', 0); // all important chars encoded
// localStorage.setItem('dust.backwardCompatibility', 1); // compatible with <script>var x = '{value|j}'</script>
// localStorage.setItem('dust.backwardCompatibility', 2); // unit tests compatible (usual encoding, vulnerable)

dust.backwardCompatibility special variable for if it's true \ not encoded in HTML and <&" not encoded in JS just backspaced \"
We don't override JSON.stringify I just use dust.JSONstringify for js flag dust.JSONstringify({'test':'alert(&#39;1&#39;)'}) with backwardCompatibility is {"test":"<script\u003ealert\u0028\'1\'\u0029<\u002fscript\u003e"}
I added dust.sanitizeURI function with flag url (for example value='javascript:alert(1)'; {value|url|s} will be ./javascript:alert%281%29) you can use it with any valid url
I changed uc with dust.encodeURIComponent (with encoding of '()!*)
escapeHtml and escapeJs the same (except dust.backwardCompatibility, it additionally encode symbols like ()[]{}= etc. and replace some control chars)

console.log(dust.JSONstringify({x:text}));
console.log(dust.escapeJs(text));
console.log(dust.escapeHtml(text));
console.log(dust.encodeURIComponent(text));

{"x":"\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000b\f\r\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f \u0021\"\u0023$\u0025&\u0027\u0028\u0029\u002a+,-.\u002f0123456789:;<\u003d\u003e\u003f@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_\u0060abcdefghijklmnopqrstuvwxyz{|}~"}
\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\t\n\u000b\u000c\r\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f\u0020\u0021\"\u0023\u0024\u0025&\u0027\u0028\u0029\u002a\u002b\u002c\u002d\u002e\u002f0123456789\u003a\u003b<\u003d\u003e\u003f\u0040ABCDEFGHIJKLMNOPQRSTUVWXYZ\u005b\u005c\u005d\u005e_\u0060abcdefghijklmnopqrstuvwxyz\u007b\u007c\u007d\u007e\u007f
&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;  
&#xfffd;&#xfffd;
&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd;&#xfffd; !&quot;#$%&amp;&#39;&#40;&#41;*&#43;&#44;&#45;&#46;&#47;0123456789&#58;&#59;&lt;&#61;&gt;?@ABCDEFGHIJKLMNOPQRSTUVWXYZ&#91;&#93;^_&#96;abcdefghijklmnopqrstuvwxyz&#123;|&#125;~&#xfffd;
%00%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F%20%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~%7F%C2%80 
