### PR TITLE
Added missing semicolons to make it possible to minify dust-full.js

### DIFF
--- a/dist/dust-full-1.1.1.js
+++ b/dist/dust-full-1.1.1.js
@@ -650,7 +650,7 @@ function filterAST(ast) {
 
 dust.filterNode = function(context, node) {
   return dust.optimizers[node[0]](context, node);
-}
+};
 
 dust.optimizers = {
   body:      compactBuffers,
@@ -675,7 +675,7 @@ dust.optimizers = {
   path:      noop,
   literal:   noop,
   comment:   nullify
-}
+};
 
 dust.pragmas = {
   esc: function(compiler, context, bodies, params) {
@@ -686,7 +686,7 @@ dust.pragmas = {
     compiler.auto = old;
     return out;
   }
-}
+};
 
 function visit(context, node) {
   var out = [node[0]];
@@ -738,7 +738,7 @@ function compile(ast, name) {
     blocks: {},
     index: 0,
     auto: "h"
-  }
+  };
 
   return "(function(){dust.register("
     + (name ? "\"" + name + "\"" : "null") + ","
@@ -786,7 +786,7 @@ function compileParts(context, body) {
 
 dust.compileNode = function(context, node) {
   return dust.nodes[node[0]](context, node);
-}
+};
 
 dust.nodes = {
   body: function(context, node) {
@@ -951,7 +951,7 @@ dust.nodes = {
   literal: function(context, node) {
     return escape(node[1]);
   }
-}
+};
 
 function compileSection(context, node, cmd) {
   return "." + cmd + "("

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -22,7 +22,7 @@ function filterAST(ast) {
 
 dust.filterNode = function(context, node) {
   return dust.optimizers[node[0]](context, node);
-}
+};
 
 dust.optimizers = {
   body:      compactBuffers,
@@ -47,7 +47,7 @@ dust.optimizers = {
   path:      noop,
   literal:   noop,
   comment:   nullify
-}
+};
 
 dust.pragmas = {
   esc: function(compiler, context, bodies, params) {
@@ -58,7 +58,7 @@ dust.pragmas = {
     compiler.auto = old;
     return out;
   }
-}
+};
 
 function visit(context, node) {
   var out = [node[0]];
@@ -110,7 +110,7 @@ function compile(ast, name) {
     blocks: {},
     index: 0,
     auto: "h"
-  }
+  };
 
   return "(function(){dust.register("
     + (name ? "\"" + name + "\"" : "null") + ","
@@ -158,7 +158,7 @@ function compileParts(context, body) {
 
 dust.compileNode = function(context, node) {
   return dust.nodes[node[0]](context, node);
-}
+};
 
 dust.nodes = {
   body: function(context, node) {
@@ -323,7 +323,7 @@ dust.nodes = {
   literal: function(context, node) {
     return escape(node[1]);
   }
-}
+};
 
 function compileSection(context, node, cmd) {
   return "." + cmd + "("


### PR DESCRIPTION
We started using the linkedin version of dustjs, but minimizing it gives javascript errors because of some missing semicolons.
