### PR TITLE
Fix for Issue #222. Code change + new test added to verify proper behavior

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -438,24 +438,12 @@ Chunk.prototype.section = function(elem, context, bodies, params) {
    // for anonymous functions that did not returns a chunk, truthiness is evaluated based on the return value
    //
    else if (elem || elem === 0) {
-     if (body) { 
-      if(context.stack.head && typeof elem === 'object') {
-       context.stack.head['$idx'] = 0;
-       context.stack.head['$len'] = 1;
-      }
-      chunk = body(this, context.push(elem));
-      if(context.stack.head && typeof elem === 'object') {
-       context.stack.head['$idx'] = undefined;
-       context.stack.head['$len'] = undefined;
-      }
-      return chunk;
-    }
-   }
-   // nonexistent, scalar false value, scalar empty string, null, 
+     if (body) return body(this, context.push(elem));
+   // nonexistent, scalar false value, scalar empty string, null,
    // undefined are all falsy
-   else if (skip) {
+  } else if (skip) {
      return skip(this, context);
-   }   
+   }  
   return this;
 };
 

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -574,6 +574,13 @@ var coreTests = [
         message: "test array reference $idx/$len {#.} section case"
       },
       {
+        name:     "array reference $idx/$len not changed in nested object",
+        source:   "{#results}{#info}{$idx}{name}-{$len} {/info}{/results}",
+        context:  { results: [ {info: {name: "Steven"}  },  {info: {name: "Richard"} } ]  },
+        expected: "0Steven-2 1Richard-2 ",
+        message: "test array reference $idx/$len not changed in nested object"
+      },
+      {
         name:     "array reference $idx/$len nested loops",
         source:   "{#A}A loop:{$idx}-{$len},{#B}B loop:{$idx}-{$len}C[0]={.C[0]} {/B}A loop trailing: {$idx}-{$len}{/A}",
         context:  {"A": [ {"B": [ {"C": ["Ca1", "C2"]}, {"C": ["Ca2", "Ca22"]} ] }, {"B": [ {"C": ["Cb1", "C2"]}, {"C": ["Cb2", "Ca2"]} ] } ] },


### PR DESCRIPTION
Reverted some changes back to like they were a long while back so that $idx/$len are not disturbed by a section over an object. Only sections on arrays will change these values. New test added to verify $idx/$len values remain intact when iterating a section and it's body is a section on an object.
