### PR TITLE
preventing dust from crash on nonexistant helper, test added

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -8,6 +8,8 @@ function getGlobal(){
 
 (function(dust) {
 
+dust.helpers = {};
+
 dust.cache = {};
 
 dust.register = function(name, tmpl) {
@@ -526,6 +528,8 @@ Chunk.prototype.helper = function(name, context, bodies, params) {
   // handle invalid helpers, similar to invalid filters
   if( dust.helpers[name]){
    return dust.helpers[name](this, context, bodies, params);
+  } else {
+    return this;
   }
 };
 

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -1156,6 +1156,18 @@ var coreTests = [
         message: "Buffer should not ignore carriage return"
       }
     ]
+  },
+  {
+    name:"Helpers",
+    tests: [
+      {
+        name:     "nonexistant helper",
+        source:   "some text {@notfound}foo{/notfound} some text",
+        context:  {},
+        expected: "some text  some text",
+        message: "Should not crash the application if an helper is not found"
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
If a nonexistent helper is referenced, the application crashes.
By passing on the current Chunk instead nothing the write chain in a compiled template doesnt get broken.
