### PR TITLE
Fix for lnkedin/dustjs issue #210. All tests passed.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,5 +1,15 @@
 (function(dust) {
 
+if (!dust.hasOwnProperty("isArray")) {
+  if (Array.isArray) {
+    dust.isArray = Array.isArray;
+  } else {
+    dust.isArray = function(arr) {
+      return Object.prototype.toString.call(arr) == "[object Array]";
+    };
+  }
+}
+
 dust.compile = function(source, name, strip) {
   try {
     if (strip) {
@@ -312,7 +322,7 @@ dust.nodes = {
         list = [];
 
     for (var i=0,len=keys.length; i<len; i++) {
-      if (Array.isArray(keys[i]))
+      if (dust.isArray(keys[i]))
         list.push(dust.compileNode(context, keys[i]));
       else
         list.push("\"" + keys[i] + "\"");


### PR DESCRIPTION
This is a fix for issue #210. All build tests pass and it runs on the browser too.

This fixes a problem on older browsers which do not have Array.isArray(), like IE8 and older.

Since "compiler.js" apparently can be used independently, simply replacing its "Array.isArray" call by a "dust.isArray" call breaks the tests. Therefore I also repeat the initialization of the dust.isArray property with the appropriate method when this one is not yet filled at compiler creation.
