### PR TITLE
Cast input to parser to a string.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -38,6 +38,7 @@ var parser = (function(){
      * unsuccessful, throws |PEG.parser.SyntaxError| describing the error.
      */
     parse: function(input, startRule) {
+      var input = String(input);
       var parseFunctions = {
         "body": parse_body,
         "part": parse_part,


### PR DESCRIPTION
Casting input to a string to ensure that string methods are available.  In node this can cause issues when feeding data from fs.readFile directly into dust.
