### PR TITLE
Remove debugger in dust-full-1.2.1.js

### DIFF
--- a/dist/dust-full-1.2.1.js
+++ b/dist/dust-full-1.2.1.js
@@ -792,7 +792,6 @@ dust.nodes = {
   },
 
   format: function(context, node) {
-    debugger;
     return ".write(" + escape(node[1] + node[2]) + ")";
   },
 


### PR DESCRIPTION
Trivial commit; you left a debugger statement in after your last merge.

Feel free to just toss this pull request and make the change the next time you commit.
