### PR TITLE
Ensures `getGlobal` returns correct `dust` object.

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -2,7 +2,7 @@ var dust = {};
 
 function getGlobal(){
   return (function(){
-    return this.dust;
+    return this.dust = (this.dust || dust);
   }).call(null);
 }
 


### PR DESCRIPTION
In Node.js, `var dust`, in the top-level scope does not declare
a global variable. 

This ensures that `global.dust` is the same object as the
`var dust` in the top level scope.

So in situations where `typeof exports` does
not correctly detect Node environments (require.js's build tool
is an example), this ensures `getGlobal` isn't placing half the
code in one object and half in another.
