### PR TITLE
unspecified parameters result in null value

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -277,7 +277,7 @@ dust.nodes = {
     if (out.length) {
       return "{" + out.join(',') + "}";
     }
-    return "null";
+    return "{}";
   },
 
   bodies: function(context, node) {


### PR DESCRIPTION
these pull requests changes the standard value of the params parameters for block contexts to an empty object instead of an null value.

this helper will break _on runtime_ if someone is doing an error when creating a template that uses that helper.

```
dust.helpers.myHelper = function(chunk, context, bodies, parameters) {
    return chunk.write(parameters.type);
};
```
