### PR TITLE
expose compile AST

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -6,7 +6,7 @@ dust.compile = function(source, name, strip) {
       source = source.replace(/^\s+/mg, '').replace(/\n/mg, '');
     }
     var ast = filterAST(dust.parse(source));
-    return compile(ast, name);
+    return dust.compileAST(ast, name);
   }
   catch(err)
   {
@@ -103,7 +103,7 @@ function convertSpecial(context, node) { return ['buffer', specialChars[node[1]]
 function noop(context, node) { return node };
 function nullify(){};
 
-function compile(ast, name) {
+dust.compileAST = function compile(ast, name) {
   var context = {
     name: name,
     bodies: [],


### PR DESCRIPTION
I believe it would be helpful to expose the compile AST function rather than it being a private function. One of our project requirements require the compile AST rather than compiling the template itself. Thanks.
