### PR TITLE
Make Dust work with The Ruby Racer.

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -78,12 +78,16 @@ if (Array.isArray) {
 dust.nextTick = (function() {
   if (typeof process !== "undefined") {
     return process.nextTick;
+  } else if (typeof setTimeout !== "undefined") {
+    return function(callback) {
+        setTimeout(callback,0);
+    };
   } else {
     return function(callback) {
-      setTimeout(callback,0);
+        callback();
     };
   }
-} )();
+})();
 
 dust.isEmpty = function(value) {
   if (dust.isArray(value) && !value.length) return true;


### PR DESCRIPTION
Added a fallback returning a plain wrapper function for the callback for environments where neither `process` nor `setTimeout` exists. This is required for Dust to work with The Ruby Racer.