### PR TITLE
Tests for #262

### DIFF
--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -218,6 +218,13 @@ var coreTests = [
     name: "partials",
     tests: [
       {
+        name:     "static_partial",
+        source:   "Hello! You have new messages.",
+        context:  { },
+        expected: "Hello! You have new messages.",
+        message: "should test a basic partial"
+      },
+      {
         name:     "partial",
         source:   "Hello {name}! You have {count} new messages.",
         context:  { name: "Mick", count: 30 },
@@ -869,6 +876,27 @@ var coreTests = [
         context:  { profile: { name: "Mick", count: 30 } },
         expected: "Hello Mick! You have 30 new messages.",
         message:  "should test partial with context"
+      },
+      {
+        name:     "partial with dynamic name",
+        source:   "{partialName}: {>\"{partialName}\" /}",
+        context:  { partialName: "static_partial" },
+        expected: "static_partial: Hello! You have new messages.",
+        message:  "should test partial with a dynamic name"
+      },
+      {
+        name:     "partial with dynamic name and values",
+        source:   "{partialName}: {>\"{partialName}\" name=Mick, count=30 /}",
+        context:  { partialName: "partial" },
+        expected: "partial: Hello Mick! You have 30 new messages.",
+        message:  "should test partial with a dynamic name"
+      },
+      {
+        name:     "partial with dynamic name and context",
+        source:   "{partialName}: {>\"\{partialName\}\":profile /}",
+        context:  { profile: { name: "Mick", count: 30 }, partialName: "partial" },
+        expected: "partial: Hello Mick! You have 30 new messages.",
+        message:  "should test partial a dynamic name and context"
       },
       {
         name:     "partial with blocks, with no default values for blocks",


### PR DESCRIPTION
Hey guys, I noticed some inconsistencies in the syntax for invoking partials with dynamic names and a scope.

Let's say this is my *scope*:
```javascript
{
  me: { name: Mickey, company: "Medallia" },
  partialName: "person"
}
```

And this is a *partial* that I've got saved in person.dust:
```dust
Hi, I'm {name}, and you can find me at {company}!
```

Here's where the problems begin. This is my *template*:
```dust
{#me}
  {> person /}
{/me}
{?me}
  {> person:me /}
{/me}
{?me}
  {> person name=me.name company=me.company /}
{/me}

{! So far so good... !}

{#me}
  {> "{partialName}" /} {! <-- This works !}
{/me}
{?me}
  {> "{partialName}":me /} {! <-- This throws a template "[blank]" not found error !}
{/me}
{?me}
  {> "{partialName}" name=me.name company=me.company /} {! <-- and this one also throws an error :( !}
{/me}
```
I would expect this to output "Hi, I'm Mickey, and you can find me at Medallia!" six times. However, the last two partial invokations throw errors.

My understanding is that this behavior is inconsistent. I've added some specs that are currently failing, and I think they should be fulfilled. 

Do you guys agree? Is there a rationale for the inconsistent syntax?

Thanks!

P.S. My actual use case for this functionality is rendering a heterogeneous collection, in which each entity is aware of its subtemplate and subtemplate-scope. I would like to render the subtemplate, even if the scope is empty, which makes the colon-syntax cleaner than a conditional.