### PR TITLE
Add component.json so dust can be easily installed with component for the browser

### DIFF
--- a/component.json
+++ b/component.json
@@ -25,7 +25,6 @@
   "scripts": [
     "lib/compiler.js",
     "lib/dust.js",
-    "lib/full.js",
     "lib/parser.js",
     "lib/server.js"
   ],

--- a/lib/full.js
+++ b/lib/full.js
@@ -1,4 +1,0 @@
-var dust = require( './dust.js' );
-require( './compiler.js' )( dust );
-dust.parse = require( './parser.js' ).parse;
-module.exports = dust;


### PR DESCRIPTION
Added a convenience 'full.js' for use when installing via component (http://github.com/component/component), eg:

```
component install linkedin/dustjs
```

Then in your component-compatible browser code:

```
var dust = require( 'dustjs-linkedin' );

dust.render( 'template', { foo: 'bar' }, function( error, output ) {
    console.log( output );
});
```

Want to be able to compile templates in the browser?:

```
var dust = require( 'dustjs-linkedin/lib/full' );

var compiled = dust.compileFn( templateAsString );
compiled( { foo: 'bar' }, function( error, output ) {
    console.log( output );
});
```
