### PR TITLE
Cache VM context across `dust.loadSource` calls.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -7,8 +7,9 @@ module.exports = function(dust) {
   compiler.parse = parser.parse;
   dust.compile = compiler.compile;
 
+  var context = vm.createContext({dust: dust});
   dust.loadSource = function(source, path) {
-    return vm.runInNewContext(source, {dust: dust}, path);
+    return vm.runInContext(source, context, path);
   };
 
   dust.nextTick = process.nextTick;


### PR DESCRIPTION
Should fix issue #288.
