### PR TITLE
upgrading jasmine-node to the latest version (1.9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "keywords": ["templates", "views"],
     "devDependencies": {
-    "jasmine-node"   :  "1.0.x",
+    "jasmine-node"   :  "1.9.x",
     "cover"          :  "0.2.x",
     "uglify-js"      :  "1.3.3"
   },

--- a/test/jasmine-test/server/specRunner.js
+++ b/test/jasmine-test/server/specRunner.js
@@ -27,10 +27,16 @@ process.argv.forEach(function(arg) {
   }
 });
 
-jasmine.executeSpecsInFolder(path.dirname(__dirname) + '/spec', (function(runner, log) {
+var options = [];
+options['specFolders'] = [path.dirname(__dirname) + '/spec'] ;
+options['isVerbose'] = isVerbose;
+options['showColors'] = showColors;
+options['onComplete'] = function(runner, log) {
   if (runner.results().failedCount === 0) {
     return process.exit(0);
   } else {
     return process.exit(1);
   }
-}), isVerbose, showColors);
+};
+
+jasmine.executeSpecsInFolder(options);


### PR DESCRIPTION
one compatibility issue fixed.

the executeSpecsInFolder method changed its signature from 

executeSpecsInFolder(specFolders, onCompleteCallback, isVerbose, showColors)

to 

executeSpecsInFolder(options)

where options contains all the data needed to execute the tests.
