### PR TITLE
Remove option to control pathScope and remove tests for old getPath

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -8,22 +8,6 @@ function getGlobal(){
 
 (function(dust) {
 
-dust.optionsDefault = { 
-  pathScope : "local"  //sets the context path scope - other option is "global"
-};
-
-dust.setOptions = function(opts) {
-   dust.options = opts?opts:dust.optionsDefault;
-   if (dust.options.pathScope === "global") {
-     Context.prototype.getPath = getPathGlobal;
-   } 
-   else if (dust.options.pathScope === "local") {
-     Context.prototype.getPath = getPathLocal;
-   }
-};
-
-dust.setOptions(dust.options);
-
 dust.helpers = {};
 
 dust.cache = {};
@@ -171,23 +155,8 @@ Context.prototype.get = function(key) {
   return this.global ? this.global[key] : undefined;
 };
 
-//original getPath - only searches local context - does not search up context 
-function getPathLocal(cur, down) {
-  var ctx = this.stack,
-      len = down.length;
-
-  if (cur && len === 0) return ctx.head;
-  ctx = ctx.head;
-  var i = 0;
-  while (ctx && i < len) {
-    ctx = ctx[down[i]];
-    i++;
-  }
-  return ctx;
-};
-
 //supports dot path resolution, function wrapped apply, and searching global paths
-function getPathGlobal(cur, down) {
+Context.prototype.getPath = function(cur, down) {
   var ctx = this.stack, ctxThis,
       len = down.length,      
       tail = cur ? undefined : this.stack.tail; 

--- a/test/core.js
+++ b/test/core.js
@@ -109,7 +109,6 @@ function testRender(unit, source, context, expected, options, baseContext, error
   var name = unit.id;
    try {
      dust.loadSource(dust.compile(source, name));
-     dust.setOptions(options);
      if (baseContext){
         context = dust.makeBase(baseContext).push(context);
      }

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -688,13 +688,6 @@ var coreTests = [
         message: "Should not find glob.globChild which is in context.global"
       },
       {
-        name: "dotted path resolution up context should not work in local mode",
-        source: "{#data.A.list}Aname{data.A.name}{/data.A.list}",
-        context: { "data":{"A":{"name":"Al","list":[{"name": "Joe"},{"name": "Mary"}],"B":{"name":"Bob","Blist":["BB1","BB2"]}}} },
-        expected: "AnameAname",
-        message: "should test usage of dotted path resolution up context in original dust mode"
-      },
-      {
         name:     "Verify leading dot path not affected in global mode",
         source:   "{#people}{.name} is {?.age}{.age} years old.{:else}not telling us their age.{/age}{/people}",
         options: {pathScope: "global"},
@@ -766,14 +759,6 @@ var coreTests = [
         context: { },
         expected: "testGlobal",
         message: "Should find glob.globChild which is in context.global"
-      },
-      {
-        name: "dotted path resolution - test switch back to local mode",
-        source: "{#data.A.list}Aname{data.A.name}{/data.A.list}",
-        options: {pathScope: "local"},
-        context: { "data":{"A":{"name":"Al","list":[{"name": "Joe"},{"name": "Mary"}],"B":{"name":"Bob","Blist":["BB1","BB2"]}}} },
-        expected: "AnameAname",
-        message: "should test usage of dotted path resolution up context in original dust mode"
       },
       {
           name: "dotted path resolution up context with partial match in current context",

--- a/test/jasmine-test/spec/renderTestSpec.js
+++ b/test/jasmine-test/spec/renderTestSpec.js
@@ -14,7 +14,6 @@ function render(test) {
     var context;
     try {
       dust.loadSource(dust.compile(test.source, test.name, test.strip));
-      dust.setOptions(test.options);
       context = test.context;
       if (test.base){
          context = dust.makeBase(test.base).push(context);
@@ -38,7 +37,6 @@ function stream(test) {
       output = "";
       try {
         dust.loadSource(dust.compile(test.source, test.name));
-        dust.setOptions(test.options);
         context = test.context;
         if (test.base){
            context = dust.makeBase(test.base).push(context);
@@ -87,7 +85,6 @@ function pipe(test) {
         if (test.base){
            context = dust.makeBase(test.base).push(context);
         }
-        dust.setOptions(test.options);
         var tpl = dust.stream(test.name, context);
         tpl.pipe({
           write: function (data) {


### PR DESCRIPTION
All tests pass for make test and make jasmine
