### PR TITLE
Add dust.render(name, callback) shortcut

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -18,6 +18,10 @@ dust.register = function(name, tmpl) {
 };
 
 dust.render = function(name, context, callback) {
+  if(typeof context == "function") {
+    callback = context;
+    context = {};
+  }
   var chunk = new Stub(callback).head;
   dust.load(name, chunk, Context.wrap(context, name)).end();
 };


### PR DESCRIPTION
This shortcut is for who wants to render a template without context params. :D 
