### PR TITLE
Template Inheritance Multiple Level and Parent block to call the parent template.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -39,6 +39,7 @@ dust.optimizers = {
   params:    visit,
   bodies:    visit,
   param:     visit,
+  mul_key:   visit,
   filters:   noop,
   key:       noop,
   path:      noop,
@@ -303,6 +304,9 @@ dust.nodes = {
     return "ctx.get(\"" + node[1] + "\")";
   },
 
+  mul_key: function(context, node) {
+    return "(" + dust.compileNode(context, node[1]) +"? " + dust.compileNode(context, node[2]) + ":"+ dust.compileNode(context, node[3]) + ")";
+  },
   path: function(context, node) {
     var current = node[1],
         keys = node[2],

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -140,7 +140,7 @@ function compileBodies(context) {
 
   for (var i=0, len=bodies.length; i<len; i++) {
     out[i] = "function body_" + i + "(chk,ctx){"
-      + blx + "return chk" + bodies[i] + ";}";
+    + (i === 0 ? blx : "") + "return chk" + bodies[i] + ";}";
   }
   return out.join('');
 };

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -216,11 +216,14 @@ Context.prototype.getBlock = function(key, chk, ctx) {
   var blocks = this.blocks;
 
   if (!blocks) return;
-  var len = blocks.length, fn;
-  while (len--) {
-    fn = blocks[len][key];
-    if (fn) return fn;
-  }
+  
+  var len = 0, fn;
+    while (len !== blocks.length) {
+      fn = blocks[len][key];
+      if (fn)
+          return fn;
+      len++;
+    }
 };
 
 Context.prototype.shiftBlocks = function(locals) {

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -212,19 +212,41 @@ Context.prototype.getBlock = function(key, chk, ctx) {
     key = key(chk, ctx).data.join("");
     chk.data = []; //ie7 perf
   }
-
-  var blocks = this.blocks;
-
+  
+  var blocks = this.blocks; 
+  
   if (!blocks) return;
   
-  var len = 0, fn;
-    while (len !== blocks.length) {
+  var len = 0, fn, parent = false;
+  
+  if(key === "parent") {
+    parent = true;
+    key = this.last_block.key;
+    len = this.last_block.len+1;
+  }
+  
+  if(!this.last_block ) {
+    this.last_block = {};
+  }
+  
+  this.last_block.key = key;
+  
+
+  while (len !== blocks.length) {
       fn = blocks[len][key];
-      if (fn)
+      if (fn) {
+        this.last_block.len = len;
           return fn;
+      }
+        
       len++;
     }
+    if (parent && this.save_block) {
+      return this.save_block;
+      
+    }
 };
+
 
 Context.prototype.shiftBlocks = function(locals) {
   var blocks = this.blocks,
@@ -508,6 +530,9 @@ Chunk.prototype.block = function(elem, context, bodies) {
   var body = bodies.block;
 
   if (elem) {
+    if(body) {
+      context.save_block = body;
+    }
     body = elem;
   }
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -49,11 +49,12 @@ var parser = (function(){
         "bodies": parse_bodies,
         "reference": parse_reference,
         "partial": parse_partial,
+        "partial_key": parse_partial_key,
         "filters": parse_filters,
         "special": parse_special,
         "identifier": parse_identifier,
         "number": parse_number,
-        "frac": parse_frac,
+        "float": parse_float,
         "integer": parse_integer,
         "path": parse_path,
         "key": parse_key,
@@ -70,6 +71,8 @@ var parser = (function(){
         "rd": parse_rd,
         "lb": parse_lb,
         "rb": parse_rb,
+        "lp": parse_lp,
+        "rp": parse_rp,
         "eol": parse_eol,
         "ws": parse_ws
       };
@@ -798,8 +801,8 @@ var parser = (function(){
       }
       
       function parse_partial() {
-        var result0, result1, result2, result3, result4, result5, result6, result7, result8;
-        var pos0, pos1, pos2;
+        var result0, result1, result2, result3, result4, result5, result6, result7, result8, result9, result10, result11, result12, result13, result14, result15, result16, result17, result18, result19, result20;
+        var pos0, pos1;
         
         reportFailures++;
         pos0 = clone(pos);
@@ -834,17 +837,7 @@ var parser = (function(){
               result3 = parse_ws();
             }
             if (result2 !== null) {
-              pos2 = clone(pos);
-              result3 = parse_key();
-              if (result3 !== null) {
-                result3 = (function(offset, line, column, k) {return ["literal", k]})(pos2.offset, pos2.line, pos2.column, result3);
-              }
-              if (result3 === null) {
-                pos = clone(pos2);
-              }
-              if (result3 === null) {
-                result3 = parse_inline();
-              }
+              result3 = parse_partial_key();
               if (result3 !== null) {
                 result4 = parse_context();
                 if (result4 !== null) {
@@ -912,9 +905,247 @@ var parser = (function(){
         if (result0 === null) {
           pos = clone(pos0);
         }
+        if (result0 === null) {
+          pos0 = clone(pos);
+          pos1 = clone(pos);
+          result0 = parse_ld();
+          if (result0 !== null) {
+            if (input.charCodeAt(pos.offset) === 62) {
+              result1 = ">";
+              advance(pos, 1);
+            } else {
+              result1 = null;
+              if (reportFailures === 0) {
+                matchFailed("\">\"");
+              }
+            }
+            if (result1 === null) {
+              if (input.charCodeAt(pos.offset) === 43) {
+                result1 = "+";
+                advance(pos, 1);
+              } else {
+                result1 = null;
+                if (reportFailures === 0) {
+                  matchFailed("\"+\"");
+                }
+              }
+            }
+            if (result1 !== null) {
+              result2 = [];
+              result3 = parse_ws();
+              while (result3 !== null) {
+                result2.push(result3);
+                result3 = parse_ws();
+              }
+              if (result2 !== null) {
+                result3 = parse_lp();
+                if (result3 !== null) {
+                  result4 = [];
+                  result5 = parse_ws();
+                  while (result5 !== null) {
+                    result4.push(result5);
+                    result5 = parse_ws();
+                  }
+                  if (result4 !== null) {
+                    result5 = parse_identifier();
+                    if (result5 !== null) {
+                      result6 = [];
+                      result7 = parse_ws();
+                      while (result7 !== null) {
+                        result6.push(result7);
+                        result7 = parse_ws();
+                      }
+                      if (result6 !== null) {
+                        if (input.charCodeAt(pos.offset) === 63) {
+                          result7 = "?";
+                          advance(pos, 1);
+                        } else {
+                          result7 = null;
+                          if (reportFailures === 0) {
+                            matchFailed("\"?\"");
+                          }
+                        }
+                        if (result7 !== null) {
+                          result8 = [];
+                          result9 = parse_ws();
+                          while (result9 !== null) {
+                            result8.push(result9);
+                            result9 = parse_ws();
+                          }
+                          if (result8 !== null) {
+                            result9 = parse_partial_key();
+                            if (result9 !== null) {
+                              result10 = [];
+                              result11 = parse_ws();
+                              while (result11 !== null) {
+                                result10.push(result11);
+                                result11 = parse_ws();
+                              }
+                              if (result10 !== null) {
+                                if (input.charCodeAt(pos.offset) === 58) {
+                                  result11 = ":";
+                                  advance(pos, 1);
+                                } else {
+                                  result11 = null;
+                                  if (reportFailures === 0) {
+                                    matchFailed("\":\"");
+                                  }
+                                }
+                                if (result11 !== null) {
+                                  result12 = [];
+                                  result13 = parse_ws();
+                                  while (result13 !== null) {
+                                    result12.push(result13);
+                                    result13 = parse_ws();
+                                  }
+                                  if (result12 !== null) {
+                                    result13 = parse_partial_key();
+                                    if (result13 !== null) {
+                                      result14 = [];
+                                      result15 = parse_ws();
+                                      while (result15 !== null) {
+                                        result14.push(result15);
+                                        result15 = parse_ws();
+                                      }
+                                      if (result14 !== null) {
+                                        result15 = parse_rp();
+                                        if (result15 !== null) {
+                                          result16 = parse_context();
+                                          if (result16 !== null) {
+                                            result17 = parse_params();
+                                            if (result17 !== null) {
+                                              result18 = [];
+                                              result19 = parse_ws();
+                                              while (result19 !== null) {
+                                                result18.push(result19);
+                                                result19 = parse_ws();
+                                              }
+                                              if (result18 !== null) {
+                                                if (input.charCodeAt(pos.offset) === 47) {
+                                                  result19 = "/";
+                                                  advance(pos, 1);
+                                                } else {
+                                                  result19 = null;
+                                                  if (reportFailures === 0) {
+                                                    matchFailed("\"/\"");
+                                                  }
+                                                }
+                                                if (result19 !== null) {
+                                                  result20 = parse_rd();
+                                                  if (result20 !== null) {
+                                                    result0 = [result0, result1, result2, result3, result4, result5, result6, result7, result8, result9, result10, result11, result12, result13, result14, result15, result16, result17, result18, result19, result20];
+                                                  } else {
+                                                    result0 = null;
+                                                    pos = clone(pos1);
+                                                  }
+                                                } else {
+                                                  result0 = null;
+                                                  pos = clone(pos1);
+                                                }
+                                              } else {
+                                                result0 = null;
+                                                pos = clone(pos1);
+                                              }
+                                            } else {
+                                              result0 = null;
+                                              pos = clone(pos1);
+                                            }
+                                          } else {
+                                            result0 = null;
+                                            pos = clone(pos1);
+                                          }
+                                        } else {
+                                          result0 = null;
+                                          pos = clone(pos1);
+                                        }
+                                      } else {
+                                        result0 = null;
+                                        pos = clone(pos1);
+                                      }
+                                    } else {
+                                      result0 = null;
+                                      pos = clone(pos1);
+                                    }
+                                  } else {
+                                    result0 = null;
+                                    pos = clone(pos1);
+                                  }
+                                } else {
+                                  result0 = null;
+                                  pos = clone(pos1);
+                                }
+                              } else {
+                                result0 = null;
+                                pos = clone(pos1);
+                              }
+                            } else {
+                              result0 = null;
+                              pos = clone(pos1);
+                            }
+                          } else {
+                            result0 = null;
+                            pos = clone(pos1);
+                          }
+                        } else {
+                          result0 = null;
+                          pos = clone(pos1);
+                        }
+                      } else {
+                        result0 = null;
+                        pos = clone(pos1);
+                      }
+                    } else {
+                      result0 = null;
+                      pos = clone(pos1);
+                    }
+                  } else {
+                    result0 = null;
+                    pos = clone(pos1);
+                  }
+                } else {
+                  result0 = null;
+                  pos = clone(pos1);
+                }
+              } else {
+                result0 = null;
+                pos = clone(pos1);
+              }
+            } else {
+              result0 = null;
+              pos = clone(pos1);
+            }
+          } else {
+            result0 = null;
+            pos = clone(pos1);
+          }
+          if (result0 !== null) {
+            result0 = (function(offset, line, column, s, e, n, n2, c, p) { var key = (s ===">")? "partial" : s; return [key, ["mul_key" ,e, n, n2], c, p] })(pos0.offset, pos0.line, pos0.column, result0[1], result0[5], result0[9], result0[13], result0[16], result0[17]);
+          }
+          if (result0 === null) {
+            pos = clone(pos0);
+          }
+        }
         reportFailures--;
         if (reportFailures === 0 && result0 === null) {
           matchFailed("partial");
+        }
+        return result0;
+      }
+      
+      function parse_partial_key() {
+        var result0;
+        var pos0;
+        
+        pos0 = clone(pos);
+        result0 = parse_key();
+        if (result0 !== null) {
+          result0 = (function(offset, line, column, k) {return ["literal", k]})(pos0.offset, pos0.line, pos0.column, result0);
+        }
+        if (result0 === null) {
+          pos = clone(pos0);
+        }
+        if (result0 === null) {
+          result0 = parse_inline();
         }
         return result0;
       }
@@ -1089,7 +1320,7 @@ var parser = (function(){
         
         reportFailures++;
         pos0 = clone(pos);
-        result0 = parse_frac();
+        result0 = parse_float();
         if (result0 === null) {
           result0 = parse_integer();
         }
@@ -1106,7 +1337,7 @@ var parser = (function(){
         return result0;
       }
       
-      function parse_frac() {
+      function parse_float() {
         var result0, result1, result2, result3;
         var pos0, pos1;
         
@@ -1157,7 +1388,7 @@ var parser = (function(){
         }
         reportFailures--;
         if (reportFailures === 0 && result0 === null) {
-          matchFailed("frac");
+          matchFailed("float");
         }
         return result0;
       }
@@ -2439,6 +2670,36 @@ var parser = (function(){
           result0 = null;
           if (reportFailures === 0) {
             matchFailed("\"]\"");
+          }
+        }
+        return result0;
+      }
+      
+      function parse_lp() {
+        var result0;
+        
+        if (input.charCodeAt(pos.offset) === 40) {
+          result0 = "(";
+          advance(pos, 1);
+        } else {
+          result0 = null;
+          if (reportFailures === 0) {
+            matchFailed("\"(\"");
+          }
+        }
+        return result0;
+      }
+      
+      function parse_rp() {
+        var result0;
+        
+        if (input.charCodeAt(pos.offset) === 41) {
+          result0 = ")";
+          advance(pos, 1);
+        } else {
+          result0 = null;
+          if (reportFailures === 0) {
+            matchFailed("\")\"");
           }
         }
         return result0;

--- a/src/dust.pegjs
+++ b/src/dust.pegjs
@@ -72,9 +72,13 @@ reference "reference"
   context followed by slash and closing brace
 ---------------------------------------------------------------------------------------------------------------------------------------*/
 partial "partial"
-  = ld s:(">"/"+") ws* n:(k:key {return ["literal", k]} / inline) c:context p:params ws* "/" rd
+  = ld s:(">"/"+") ws* n:(partial_key) c:context p:params ws* "/" rd
   { var key = (s ===">")? "partial" : s; return [key, n, c, p] }
+  / ld s:(">"/"+") ws* lp ws* e:identifier ws* "?" ws* n:(partial_key) ws* ":" ws* n2:(partial_key) ws* rp c:context p:params ws* "/" rd
+  { var key = (s ===">")? "partial" : s; return [key, ["mul_key" ,e, n, n2], c, p] }
 
+partial_key
+  = k:key {return ["literal", k]} / inline
 /*-------------------------------------------------------------------------------------------------------------------------------------
    filters is defined as matching a pipe character followed by anything that matches the key
 ---------------------------------------------------------------------------------------------------------------------------------------*/
@@ -191,6 +195,12 @@ lb
 
 rb
   = "]"
+
+lp
+  = "("
+
+rp
+  = ")"
 
 eol 
   = "\n"        //line feed

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -223,6 +223,18 @@ var coreTests = [
         message: "should test multiple child template"
       },
       {
+        name:     "child_child_template_or_child_template_by_variable",
+        source:   "{>(xhr ? base_template : child_template)/}" +
+                  "{+main/}"          +
+                  "{<title}"            +
+                  "Child Child Title"       +
+                  "{/title}"            ,
+                  
+        context:  {xhr: true},
+        expected: "Start\nChild Child Title\nBase Content\nEnd",
+        message: "should test template inheritance with partial defined by context variable"
+      },
+      {
         name:     "child_child_template with parent",
         source:   "{^xhr}"              +
                   "{>child_template/}" +

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -255,7 +255,7 @@ var coreTests = [
                   
         context:  {xhr: false},
         expected: "Start\nChild Child Title\nChild Child Content\nChild Content\nBase Content\nEnd",
-        message: "should test multiple child template with parent"
+        message: "should test multiple child template with multiple parent blocks"
       },              
       {
         name:     "recursion",

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -189,6 +189,21 @@ var coreTests = [
         expected: "Start\nChild Title\nChild Content\nEnd",
         message: "should test child template"
       },
+              {
+        name:     "child_child_template",
+        source:   "{^xhr}"              +
+                  "{>child_template/}" +
+                  "{:else}"             +
+                  "{+main/}"          +
+                  "{/xhr}"              +
+                  "{<title}"            +
+                  "Child Child Title"       +
+                  "{/title}"            ,
+                  
+        context:  {xhr: false},
+        expected: "Start\nChild Child Title\nChild Content\nEnd",
+        message: "should test child template"
+      },
       {
         name:     "recursion",
         source:   "{name}{~n}{#kids}{>recursion:./}{/kids}",

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -189,7 +189,25 @@ var coreTests = [
         expected: "Start\nChild Title\nChild Content\nEnd",
         message: "should test child template"
       },
-              {
+      {
+        name:     "child_template_with_parent",
+        source:   "{^xhr}"              +
+                  "{>base_template/}" +
+                  "{:else}"             +
+                  "{+main/}"          +
+                  "{/xhr}"              +
+                  "{<title}"            +
+                  "Child Title"       +
+                  "{/title}"            +
+                  "{<main}"             +
+                  "Child Content{~n}"     +
+                  "{+parent/}"       +
+                  "{/main}",
+        context:  {xhr: false},
+        expected: "Start\nChild Title\nChild Content\nBase Content\nEnd",
+        message: "should test child template"
+      },
+      {
         name:     "child_child_template",
         source:   "{^xhr}"              +
                   "{>child_template/}" +
@@ -202,8 +220,43 @@ var coreTests = [
                   
         context:  {xhr: false},
         expected: "Start\nChild Child Title\nChild Content\nEnd",
-        message: "should test child template"
+        message: "should test multiple child template"
       },
+      {
+        name:     "child_child_template with parent",
+        source:   "{^xhr}"              +
+                  "{>child_template/}" +
+                  "{:else}"             +
+                  "{+main/}"          +
+                  "{/xhr}"              +
+                  "{<title}"            +
+                  "Child Child Title{~n}"       +
+                  "{+parent/}"       +
+                  "{/title}"            ,
+                  
+        context:  {xhr: false},
+        expected: "Start\nChild Child Title\nChild Title\nChild Content\nEnd",
+        message: "should test multiple child template with parent"
+      },
+      {
+        name:     "child_child_template with multiple parents",
+        source:   "{^xhr}"              +
+                  "{>child_template_with_parent/}" +
+                  "{:else}"             +
+                  "{+main/}"          +
+                  "{/xhr}"              +
+                  "{<title}"            +
+                  "Child Child Title"       +
+                  "{/title}"            +
+                  "{<main}"             +
+                  "Child Child Content{~n}"     +
+                  "{+parent/}"       +
+                  "{/main}",
+                  
+        context:  {xhr: false},
+        expected: "Start\nChild Child Title\nChild Child Content\nChild Content\nBase Content\nEnd",
+        message: "should test multiple child template with parent"
+      },              
       {
         name:     "recursion",
         source:   "{name}{~n}{#kids}{>recursion:./}{/kids}",


### PR DESCRIPTION
Add the feature of multiple levels in template inheritance, after only works in 1 level, now support multiple level, and implement de {+parent/} block to concat current template with the parent template.

Adding and tested all unit test in coreTest.js