### PR TITLE
Fix issue #317. Falsey value at end of path

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -170,7 +170,9 @@ Context.prototype.getPath = function(cur, down) {
     i++;
     while (!ctx && !cur){
         //if there was a partial match, don't search further
-    	if (i > 1) return undefined;
+	// Note: a falsey value at the end of a matched path also comes here.
+	// This returns the value or undefined if we just have a partial match.
+    	if (i > 1) return ctx;
     	if (tail){
     	  ctx = tail.head;
     	  tail = tail.tail;

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -703,6 +703,14 @@ var coreTests = [
         message: "should test the leading dot behavior preserved"
      },
      {
+        name: "Standard dotted path with falsey value. Issue 317",
+        source: "{foo.bar}",
+        options: {pathScope: "global"},
+        context: { foo: {bar: 0} },
+        expected: "0",
+        message: "should work when value at end of path is falsey"
+     },
+     {
         name: "dotted path resolution up context",
         source: "{#data.A.list}Aname{data.A.name}{/data.A.list}",
         options: {pathScope: "global"},


### PR DESCRIPTION
Fix added to handle falsey at end of path use case. Test added to verify it works. New test failed before the change. We need to cut a new 2.0.1 version soon. This issue could affect many folks.
