### PR TITLE
Adding support for CommonJS browser environments.

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,0 +1,11 @@
+// Including compiler for CommonJS browser environments.
+// this replaces server.js via the "browser" attribute on package.json
+// for bundling environments like browserify
+module.exports = function (dust) {
+  var parser = require('./parser'),
+    compiler = require('./compiler')(dust);
+
+  compiler.parse = parser.parse;
+  dust.compile = compiler.compile;
+  dust.optimizers = compiler.optimizers;
+};

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "uglify-js"       :  "1.3.3",
     "pegjs"           :  "0.7.0"
   },
+  "browser": {
+    "./lib/server.js": "./lib/browser.js"
+  },
   "license": "MIT",
   "engine": {
     "node": ">=0.5"


### PR DESCRIPTION
This commit replaces lib/server.js with lib/browser.js when the code is being bundled as CommonJS for browser environments using tools that look at the "browser" option on the package.json file as outlined on https://gist.github.com/shtylman/4339901.

The change allows to require the "dustjs-linkedin" on browser environments without having to make use of the "vm" module as it currently occurs when the lib/server.js is being bundled.

I've tested this change by running:

```
browserify --standalone dust  . > ./dist/browserified-dust.js
```

and updating the test/test.html scripts to include the browserified version instead of lib/[dust,parser,compiler].js.

A sample browserified version can be found on https://gist.github.com/bermi/03ee5117c0dfca74322b. It happens to be just 7KB larger than the combined version.
