### PR TITLE
Add Node.js require() handler for .dust files

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -14,4 +14,22 @@ dust.loadSource = function(source, path) {
 
 dust.nextTick = process.nextTick;
 
+// Publish a Node.js require() handler for .dust files
+if (require.extensions) {
+    require.extensions[".dust"] = function(module, filename) {
+        var fs = require("fs");
+        var text = fs.readFileSync(filename, 'utf8');
+        var source = dust.compile(text, filename);
+        var body = dust.loadSource(source, filename);
+
+        module.exports = body;
+        module.exports.render = function (context, callback) {
+          dust.render(filename, context, callback);
+        };
+        module.exports.stream = function (context) {
+          return dust.stream(filename, context);
+        };
+    };
+}
+
 module.exports = dust;


### PR DESCRIPTION
When working on server code with templates in individual `.dust` files, it is convenient to be able to `require()` those files into useful modules, like so:

```javascript
var dust = require("dustjs-linkedin");
var helloTemplate = require("./templates/hello");
helloTemplate({name: "Nemo"}, function(err, result) {
    if (err) throw err;
    console.log(result);
});
```

This patch provides a `require()` handler to make that possible.