### PR TITLE
Adding file path to compiler syntax exception

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -8,7 +8,7 @@ dust.compile = function(source, name) {
   catch(err)
   {
     if(!err.line || !err.column) throw err;    
-    throw new SyntaxError(err.message + " At line : " + err.line + ", column : " + err.column);
+    throw new SyntaxError(err.message + " At line : " + err.line + ", column : " + err.column + ", file : " + name);
   }
 };
 


### PR DESCRIPTION
When you're in someone else's code it's helpful to have the path in the exception.
