### PR TITLE
Fix Issue #277. Make test page work in Chrome

### DIFF
--- a/test/dust_files/coreTests.js
+++ b/test/dust_files/coreTests.js
@@ -1,0 +1,1563 @@
+var coreTests = [
+  { 
+    name: "core tests",
+    tests: [
+      {
+        name:     "streaming render",
+        source:   "{#stream}{#delay}{.}{/delay}{/stream}",
+        context:  (function(){
+                    var d = 1;
+                    return {
+                      stream: function() {
+                        return "asynchronous templates for the browser and node.js".split('');
+                      },
+                      delay: function(chunk, context, bodies) {
+                        return chunk.map(function(chunk) {
+                          setTimeout(function() {
+                            chunk.render(bodies.block, context).end();
+                          }, d++ * 15);
+                        });
+                      }
+                    };
+                  }),
+        expected: '',
+        message: "should test the stream rendering"
+      },
+      {
+        name:     "hello_world",
+        source:   "Hello World!",
+        context:  {},
+        expected: "Hello World!",
+        message: "should test basic text rendering"
+      },
+      {
+        name:     "global_template",
+        source:   '{#helper foo="bar" boo="boo"} {/helper}',
+        context:  { "helper": function(chunk, context, bodies, params) 
+                     {
+                      var len = Object.keys(context.global.__templates__).length;
+                      // top of the current stack
+                      currentTemplateName = context.global.__templates__[len - 1];
+                      return chunk.write(currentTemplateName);
+                     }
+                  },
+        expected: "global_template",
+        message: "should render the template name"
+       },
+       {
+         name:     "apps/test/foo.tl&v=0.1",
+         source:   '{#helper foo="bar" boo="boo" template="tl/apps/test"} {/helper}',
+         context:  { "helper": function(chunk, context, bodies, params)
+                    {
+                      var len = Object.keys(context.global.__templates__).length;
+                      // top of the current stack
+                      currentTemplateName = context.global.__templates__[len - 1];
+                      return chunk.write(currentTemplateName);
+                    } 
+                   },
+        expected: "apps/test/foo.tl&v=0.1",
+        message: "should render the template name with paths"
+      },
+      {
+         name:     "makeBase_missing_global",
+         source:   '{#helper}{/helper}',
+         context:  { "helper": function(chunk, context, bodies, params)
+                    {
+                      var newContext = {};
+                      return bodies.block(chunk, dust.makeBase(newContext));
+                    } 
+                   },
+        expected: "",
+        message: "should render the helper with missing global context"
+      },
+      {
+        name:     "reference",
+        source:   "{?one}{one}{/one}",
+        context:   {"one": 0 },
+        expected: "0",
+        message: "should test a basic reference"
+      },
+      {
+        name:     "implicit array",
+        source:   "{#names}{.}{~n}{/names}",
+        context:  { names: ["Moe", "Larry", "Curly"] },
+        expected: "Moe\nLarry\nCurly\n",
+        message: "should test an implicit array"
+      },
+      {
+        name:     "inline param from outer scope",
+        source:   "{#person foo=root}{foo}: {name}, {age}{/person}",
+        context:  { root: "Subject", person: { name: "Larry", age: 45 } },
+        expected: "Subject: Larry, 45",
+        message: "should test renaming a key"
+      },
+      {
+        name:     "force local",
+        source:   "{#person}{.root}: {name}, {age}{/person}",
+        context:  { root: "Subject", person: { name: "Larry", age: 45 } },
+        expected: ": Larry, 45",
+        message: "should test force a key"
+      },
+      {
+        name:     "filter un-escape",
+        source:   "{safe|s}{~n}{unsafe}",
+        context:  { safe: "<script>alert('Hello!')</script>", unsafe: "<script>alert('Goodbye!')</script>" },
+        expected: "<script>alert('Hello!')</script>\n&lt;script&gt;alert(&#39;Goodbye!&#39;)&lt;/script&gt;",
+        message: "should test escaped characters"
+      },
+      {
+        name:     "escape pragma",
+        source:   "{%esc:s}\n  {unsafe}{~n}\n  {%esc:h}\n    {unsafe}\n  {/esc}\n{/esc}",
+        context:  { unsafe: "<script>alert('Goodbye!')</script>" },
+        expected: "<script>alert('Goodbye!')</script>\n&lt;script&gt;alert(&#39;Goodbye!&#39;)&lt;/script&gt;",
+        message: "should test escape_pragma"
+      },
+      {
+         name:   "use . for creating a block and set params",
+         source: "{#. test=\"you\"}{name} {test}{/.}",
+         context: { name: "me"},
+         expected: "me you",
+         message: ". creating a block"
+      },
+      {
+        name:     "functions in context",
+        source:   "Hello {type} World!",
+        context:  {
+                    type: function(chunk) {
+                      return "Sync";
+                    }
+                  },
+        expected: "Hello Sync World!",
+        message: "should functions in context"
+      },
+      {
+        name:     "async functions in context",
+        source:   "Hello {type} World!",
+        context:  {
+                    type: function(chunk) {
+                      return chunk.map(function(chunk) {
+                        dust.nextTick(function() {
+                          chunk.end("Async");
+                        });
+                      });
+                    }
+                  },
+        expected: "Hello Async World!",
+        message: "should test functions in context"
+      },
+      {
+        name:     "sync chunk write test",
+        source:   "Hello {type} World!",
+        context:  {
+                    type: function(chunk) {
+                      return chunk.write("Chunky");
+                    }
+                  },
+        expected: "Hello Chunky World!",
+        message: "should test sync chunk write"
+      },
+      {
+        name:     "base_template",
+        source:   "Start{~n}"       +
+                  "{+title}"        +
+                  "Base Title"    +
+                  "{/title}"        +
+                  "{~n}"            +
+                  "{+main}"         +
+                  "Base Content"  +
+                  "{/main}"         +
+                  "{~n}"            +
+                  "End",
+        context:  {},
+        expected: "Start\nBase Title\nBase Content\nEnd",
+        message: "should test base template"
+      },
+      {
+        name:     "child_template",
+        source:   "{^xhr}"              +
+                  "{>base_template/}" +
+                  "{:else}"             +
+                  "{+main/}"          +
+                  "{/xhr}"              +
+                  "{<title}"            +
+                  "Child Title"       +
+                  "{/title}"            +
+                  "{<main}"             +
+                  "Child Content"     +
+                  "{/main}",
+        context:  {xhr: false},
+        expected: "Start\nChild Title\nChild Content\nEnd",
+        message: "should test child template"
+      },
+      {
+        name:     "issue322",
+        source:   'hi{+"{name}"/}',
+        context:  {},
+        expected: "hi", 
+        message: "should setup base template for next test. hi should not be part of base block name"
+
+      },
+      {
+        name:     "issue322 use base template picks up prefix chunk data",
+        source:   '{>issue322 name="abc"/}' +
+		   "{<abc}ABC{/abc}",
+        context:  {},
+        expected: "hiABC",
+        message: "should use base template and honor name passed in"
+
+      },
+      {
+        name:     "recursion",
+        source:   "{name}{~n}{#kids}{>recursion:./}{/kids}",
+        context:  {
+                    name: '1',
+                    kids: [
+                      {
+                        name: '1.1',
+                        kids: [
+                          {name: '1.1.1'}
+                        ]
+                      }
+                    ]
+                  },
+        expected: "1\n1.1\n1.1.1\n",
+        message: "should test recursion"
+      },
+      {
+        name:     "comments",
+        source:   "{!\n"                      +
+                  "  Multiline\n"             +
+                  "  {#foo}{bar}{/foo}\n"     +
+                  "!}\n"                      +
+                  "{!before!}Hello{!after!}",
+        context:  {},
+        expected: "Hello",
+        message: "should test comments"
+      },
+      {
+        name:     "context",
+        source:   "{#list:projects}{name}{:else}No Projects!{/list}",
+        context:  {
+                    list: function(chunk, context, bodies) {
+                      var items = context.current(),
+                          len   = items.length;
+
+                      if (len) {
+                        chunk.write("<ul>\n");
+                        for (var i=0; i<len; i++) {
+                          chunk = chunk.write("<li>")
+                            .render(bodies.block, context.push(items[i]))
+                            .write("</li>\n");
+                        }
+                        return chunk.write("</ul>");
+                      } else if (bodies['else']) {
+                        return chunk.render(bodies['else'], context);
+                      }
+                      return chunk;
+                    },
+
+                    projects: [
+                      {name: "Mayhem"},
+                      {name: "Flash"},
+                      {name: "Thunder"}
+                    ]
+                  },
+        expected: "<ul>\n"             +
+                  "<li>Mayhem</li>\n"  +
+                  "<li>Flash</li>\n"   +
+                  "<li>Thunder</li>\n" +
+                  "</ul>",
+        message: "should test the context"
+      }
+    ]
+  },
+  {
+    name: "truth/falsy tests",
+    tests: [
+      {
+        name:     "false value in context is treated as empty, same as undefined",
+        source:   "{false}",
+        context:  { "false": false },
+        expected: "",
+        message: "should test for false in the context, evaluated and prints nothing"
+      },
+      {
+        name:     "numeric 0 value in context is treated as non empty",
+        source:   "{zero}",
+        context:  { "zero": 0 },
+        expected: "0",
+        message: "should test for numeric zero in the context, prints the numeric zero"
+      },
+      {
+        name:     "empty string context is treated as empty",
+        source:   "{emptyString}",
+        context:  { "emptyString": "" },
+        expected: "",
+        message: "should test emptyString, prints nothing"
+      },
+      {
+        name:     "empty string, single quoted in context is treated as empty",
+        source:   "{emptyString}",
+        context:  { "emptyString": '' },
+        expected: "",
+        message: "should test emptyString single quoted, prints nothing"
+      },
+      {
+        name:     "null in the context treated as empty",
+        source:   "{NULL}",
+        context:  { "NULL": null },
+        expected: "",
+        message: "should test null in the context treated as empty"
+      },
+      {
+        name:     "undefined in the context treated as empty",
+        source:   "{UNDEFINED}",
+        context:   {"UNDEFINED": undefined },
+        expected: "",
+        message: "should test undefined in the context treated as empty"
+      },
+      {
+        name:     "undefined string in the context treated as non empty",
+        source:   "{UNDEFINED}",
+        context:   {"UNDEFINED": "undefined"},
+        expected: "undefined",
+        message: "should test string undefined in the context as non empty"
+      },
+      {
+        name:     "null is treated as empty in exists",
+        source:   "{?scalar}true{:else}false{/scalar}",
+        context:   {"scalar": null},
+        expected: "false",
+        message:  "should test null as empty in exists section"
+      },
+      {
+        name:     "undefined is treated as empty in exists",
+        source:   "{?scalar}true{:else}false{/scalar}",
+        context:   {"scalar": undefined},
+        expected: "false",
+        message:  "should test null treated as empty in exists"
+      },
+      {
+        name:     "null is treated as truthy in not exists",
+        source:   "{^scalar}true{:else}false{/scalar}",
+        context:   {"scalar": null},
+        expected: "true",
+        message:  "should test null as truthy in not exists"
+       },
+       {
+        name:     "undefined is treated as truthy in not exists",
+        source:   "{^scalar}true{:else}false{/scalar}",
+        context:   {"scalar": undefined},
+        expected: "true",
+        message:  "should test undefined as truthy in not exists"
+       },
+       {
+        name:     "undefined is treated as empty in exists",
+        source:   "{?scalar}true{:else}false{/scalar}",
+        context:   {"scalar": undefined},
+        expected: "false",
+        message:  "should test null treated as empty in exists"
+       }
+    ]
+  },
+  {
+    name: "scalar data tests",
+    tests: [
+      {
+        name:     "scalar null in a # section",
+        source:   "{#scalar}true{:else}false{/scalar}",
+        context:   {"scalar": null},
+        expected: "false",
+        message:  "should test for a scalar null in a # section"
+      },
+      {
+        name:     "scalar numeric 0 in a # section",
+        source:   "{#scalar}true{:else}false{/scalar}",
+        context:   {"scalar": 0},
+        expected: "true",
+        message:  "should test for a scalar numeric 0 in a # section"
+      },
+      {
+        name:     "scalar numeric non-zero in a # section",
+        source:   "{#scalar}true{:else}false{/scalar}",
+        context:   {"scalar": 42},
+        expected: "true",
+        message:  "should test for a scalar numeric non-zero in a # section"
+      },
+      {
+        name:     "scalar non empty string in a # section",
+        source:   "{#scalar}true{:else}false{/scalar}",
+        context:   {"scalar": 'abcde'},
+        expected: "true",
+        message:  "should test for a scalar string in a # section"
+      },
+      {
+        name:     "scalar non empty string in a # section",
+        source:   "{#scalar}{.}{:else}false{/scalar}",
+        context:   {"scalar": 'abcde'},
+        expected: "abcde",
+        message:  "should test for a scalar string in a # section"
+      },
+      {
+        name:     "missing scalar value",
+        source:   "{#scalar}true{:else}false{/scalar}",
+        context:   {"foo": 0},
+        expected: "false",
+        message:  "should test a missing/undefined scalar value"
+      },
+      {
+        name:     "scalar true value in the # section",
+        source:   "{#scalar}true{:else}false{/scalar}",
+        context:   {"scalar": true},
+        expected: "true",
+        message:  "shoud test for scalar true value in the # section"
+      },
+      {
+        name:     "scalar false value in the # section",
+        source:   "{#scalar}true{:else}false{/scalar}",
+        context:   {"scalar": false},
+        expected: "false",
+        message:  "shoud test for scalar false value in the # section"
+      },
+      {
+        name:     "scalar values true and false are supported in # nor else blocks ",
+        source:   "{#foo}"         +
+                  "foo,{~s}"     +
+                  "{:else}"        +
+                  "not foo,{~s}" +
+                  "{/foo}"         +
+                  "{#bar}"         +
+                  "bar!"         +
+                  "{:else}"        +
+                  "not bar!"     +
+                  "{/bar}",
+        context:  { foo: true, bar: false },
+        expected: "foo, not bar!",
+        message:"should test scalar values true and false are supported in # nor else blocks"
+      }
+    ]
+  },
+  {
+    name: "empty data tests",
+    tests: [
+      {
+        name:     "empty array is treated as empty in exists",
+        source:   "{?array}true{:else}false{/array}",
+        context:   {"array": []},
+        expected: "false",
+        message:  "empty array is treated as empty in exists"
+      },
+      {
+        name:     "empty {} is treated as non empty in exists",
+        source:   "{?object}true{:else}false{/object}",
+        context:  {"object": {}},
+        expected: "true",
+        message:  "empty {} is treated as non empty in exists"
+      },
+      {
+        name:     "empty array is treated as empty in a section",
+        source:   "{#array}true{:else}false{/array}",
+        context:   {"array": []},
+        expected: "false",
+        message:  "empty array is treated as empty in a section"
+      },
+      {
+        name:     "empty {} is treated as non empty in a section",
+        source:   "{#object}true{:else}false{/object}",
+        context:  {"object": {}},
+        expected: "true",
+        message:  "empty {} is treated as non empty"
+      },
+      {
+        name:     "non-empty array in a reference",
+        source:   "{array}",
+        context:   {"array": ['1','2']},
+        expected: "1,2",
+        message: "non-empty array in a reference"
+      },
+      {
+        name:     "null string in the context treated as non empty",
+        source:   "{NULL}",
+        context:   {"NULL": "null" },
+        expected: "null",
+        message: "should test null string in the context treated as non empty"
+      },
+      {
+        name:     "string 0 value in context is treated as non empty",
+        source:   "{zero}",
+        context:   {"zero": "0" },
+        expected: "0",
+        message: "should test for string zero in the context, prints zero"
+      },
+      {
+        name:     "empty array",
+        source:   "{#names}{title} {name}{~n}{/names}",
+        context:  { title: "Sir", names: [] },
+        expected: "",
+        message: "should test an empty array"
+      }
+    ]
+  },
+  {
+    name: "array/index-access tests",
+    tests: [
+      {
+        name:     "array",
+        source:   "{#names}{title} {name}{~n}{/names}",
+        context:  { title: "Sir", names: [ { name: "Moe" }, { name: "Larry" }, { name: "Curly" } ] },
+        expected: "Sir Moe\nSir Larry\nSir Curly\n",
+        message: "should test an array"
+      },
+      {
+        name:     "accessing array element by index when element value is a primitive",
+        source:   '{do.re[0]}',
+        context:  { "do": { "re" : ["hello!","bye!"] } },
+        expected: "hello!",
+        message: "should return a specific array element by index when element value is a primitive"
+      },
+      {
+        name:     "accessing array by index when element value is a object",
+        source:   '{do.re[0].mi}',
+        context:  { "do": { "re" : [{"mi" : "hello!"},"bye!"] } },
+        expected: "hello!",
+        message: "should return a specific array element by index when element value is a object"
+      },
+      {
+        name:     "accessing array by index when element is a nested object",
+        source:   '{do.re[0].mi[1].fa}',
+        context:  { "do": { "re" : [{"mi" : ["one", {"fa" : "hello!"}]},"bye!"] } },
+        expected: "hello!",
+        message: "should return a specific array element by index when element is a nested object"
+      },
+      {
+        name:     "accessing array by index when element is list of primitives",
+        source:   '{do[0]}',
+        context:  { "do": ["lala", "lele"] },
+        expected: "lala",
+        message: "should return a specific array element by index when element is list of primitives"
+      },
+      {
+        name:     "accessing array inside a loop using the current context",
+        source:   '{#list3}{.[0].biz}{/list3}',
+        context:  { "list3": [[ { "biz" : "123" } ], [ { "biz" : "345" } ]]},
+        expected: "123345",
+        message: "should return a specific array element using the current context"
+      },
+      {
+        name:     "array: reference $idx in iteration on objects",
+        source:   "{#names}({$idx}).{title} {name}{~n}{/names}",
+        context:  { title: "Sir", names: [ { name: "Moe" }, { name: "Larry" }, { name: "Curly" } ] },
+        expected: "(0).Sir Moe\n(1).Sir Larry\n(2).Sir Curly\n",
+        message: "array: reference $idx in iteration on objects"
+      },
+      {
+        name:     "array: reference $len in iteration on objects",
+        source:   "{#names}Size=({$len}).{title} {name}{~n}{/names}",
+        context:  { title: "Sir", names: [ { name: "Moe" }, { name: "Larry" }, { name: "Curly" } ] },
+        expected: "Size=(3).Sir Moe\nSize=(3).Sir Larry\nSize=(3).Sir Curly\n",
+        message: "test array: reference $len in iteration on objects"
+      },
+      {
+        name:     "array reference $idx in iteration on simple type",
+        source:   "{#names}({$idx}).{title} {.}{~n}{/names}",
+        context:  { title: "Sir", names: [ "Moe", "Larry", "Curly" ] },
+        expected: "(0).Sir Moe\n(1).Sir Larry\n(2).Sir Curly\n",
+        message: "test array reference $idx in iteration on simple types"
+      },
+      {
+        name: "array reference $len in iteration on simple type",
+        source: "{#names}Size=({$len}).{title} {.}{~n}{/names}",
+        context:  { title: "Sir", names: [ "Moe", "Larry", "Curly" ] },
+        expected: "Size=(3).Sir Moe\nSize=(3).Sir Larry\nSize=(3).Sir Curly\n",
+        message: "test array reference $len in iteration on simple types"
+      },
+      {
+        name: "array reference $idx/$len on empty array case",
+        source: "{#names}Idx={$idx} Size=({$len}).{title} {.}{~n}{/names}",
+        context:  { title: "Sir", names: [ ] },
+        expected: "",
+        message: "test array reference $idx/$len on empty array case"
+      },
+      {
+        name: "array reference $idx/$len on single element case (scalar case)",
+        source: "{#name}Idx={$idx} Size={$len} {.}{/name}",
+        context:  { name: "Just one name" },
+        expected: "Idx= Size= Just one name",
+        message: "test array reference $idx/$len on single element case"
+      },
+      {
+        name: "array reference $idx/$len {#.} section case",
+        source: "{#names}{#.}{$idx}{.} {/.}{/names}",
+        context:  { names:  ["Moe", "Larry", "Curly"] },
+        expected: "0Moe 1Larry 2Curly ",
+        message: "test array reference $idx/$len {#.} section case"
+      },
+      {
+        name: "array reference $idx/$len not changed in nested object",
+        source: "{#results}{#info}{$idx}{name}-{$len} {/info}{/results}",
+        context:  { results: [ {info: {name: "Steven"}  },  {info: {name: "Richard"} } ]  },
+        expected: "0Steven-2 1Richard-2 ",
+        message: "test array reference $idx/$len not changed in nested object"
+      },
+      {
+        name: "array reference $idx/$len nested loops",
+        source: "{#A}A loop:{$idx}-{$len},{#B}B loop:{$idx}-{$len}C[0]={.C[0]} {/B}A loop trailing: {$idx}-{$len}{/A}",
+        context:  {"A": [ {"B": [ {"C": ["Ca1", "C2"]}, {"C": ["Ca2", "Ca22"]} ] }, {"B": [ {"C": ["Cb1", "C2"]}, {"C": ["Cb2", "Ca2"]} ] } ] },
+        expected: "A loop:0-2,B loop:0-2C[0]=Ca1 B loop:1-2C[0]=Ca2 A loop trailing: 0-2A loop:1-2,B loop:0-2C[0]=Cb1 B loop:1-2C[0]=Cb2 A loop trailing: 1-2",
+        message: "test array reference $idx/$len nested loops"
+      },
+      {
+        name: "using idx in array reference Accessing",
+        source: "{#list4} {name} {number[$idx]} {$idx}{/list4}",
+        context: { list4: [ {name:"Dog", number: [1,2,3]}, {name:"Cat", number: [4,5,6]}] },
+        expected: " Dog 1 0 Cat 5 1",
+        message: "should test the array reference access with idx"
+      },
+      {
+        name: "using len in array reference Accessing",
+        source: "{#list4} {name} {number[$len]}{/list4}",
+        context: { list4: [ {name:"Dog", number: [1,2,3]}, {name:"Cat", number: [4,5,6]}] },
+        expected: " Dog 3 Cat 6",
+        message: "should test the array reference access with len"
+      },
+      {
+        name: "using idx in array reference Accessing",
+        source: "{#list3}{.[$idx].biz}{/list3}",
+        context: { "list3": [[ { "biz" : "123" } ], [ { "biz" : "345" }, { "biz" : "456" } ]]},
+        expected: "123456",
+        message: "should test the array reference access with idx and current context"
+      },
+      {
+        name: "using len in array reference Accessing",
+        source: "{#list3}{.[$len].idx}{/list3}",
+        context: { "list3": [ 
+                    [{"idx": "0"},
+                     {"idx": "1"},
+                     {"idx": "2"}],
+                    [{"idx": "0"},
+                     {"idx": "1"},
+                     {"idx": "2"}]
+                    ]
+        },
+        expected: "22",
+        message: "should test the array reference access with len and current context"
+      }
+    ]
+  },
+  {
+    name: "object tests",
+    tests: [
+      {
+        name:     "object",
+        source:   "{#person}{root}: {name}, {age}{/person}",
+        context:  { root: "Subject", person: { name: "Larry", age: 45 } },
+        expected: "Subject: Larry, 45",
+        message: "should test an object"
+      },
+      {
+        name:     "path",
+        source:   "{foo.bar}",
+        context:  { foo: {bar: "Hello!"} },
+        expected: "Hello!",
+        message: "should test an object path"
+      }
+    ]
+  },
+  {
+    name: "conditional tests",
+    tests: [
+      {
+        name:     "conditional",
+        source:   "{?tags}"                     +
+                  "<ul>{~n}"                  +
+                  "{#tags}"                 +
+                  "{~s} <li>{.}</li>{~n}" +
+                  "{/tags}"                 +
+                  "</ul>"                     +
+                  "{:else}"                     +
+                  "No Tags!"                  +
+                  "{/tags}"                     +
+                  "{~n}"                        +
+                  "{^likes}"                    +
+                  "No Likes!"                 +
+                  "{:else}"                     +
+                  "<ul>{~n}"                  +
+                  "{#likes}"                +
+                  "{~s} <li>{.}</li>{~n}" +
+                  "{/likes}"                +
+                  "</ul>"                     +
+                  "{/likes}",
+        context:  { tags: [], likes: ["moe", "larry", "curly", "shemp"] },
+        expected: "No Tags!\n"                    +
+                  "<ul>\n"                        +
+                  "  <li>moe</li>\n"              +
+                  "  <li>larry</li>\n"            +
+                  "  <li>curly</li>\n"            +
+                  "  <li>shemp</li>\n"            +
+                  "</ul>",
+        message: "should test conditional tags"
+      },
+      {
+        name:   "empty else block",
+        source: "{#foo}full foo{:else}empty foo{/foo}",
+        context: { foo: []},
+        expected: "empty foo",
+        message: "should test else block when array empty"
+      }
+    ]
+  },
+  {
+    name: "nested path tests",
+    tests: [
+       { 
+        name: "Verify local mode leading dot path in local mode",
+        source: "{#people}{.name} is {?.age}{.age} years old.{:else}not telling us their age.{/age}{/people}",
+        context:  {
+             "name": "List of people",
+             "age": "8 hours",
+             "people": [
+               { "name": "Alice" },
+               { "name": "Bob", "age": 42 },
+              ]
+           },
+        expected: "Alice is not telling us their age.Bob is 42 years old.",
+        message: "should test the leading dot behavior in local mode"
+      },
+      {
+        name: "check nested ref in global does not work in local mode",
+        source: "{glob.globChild}",
+        context: { },
+        expected: "",
+        message: "Should not find glob.globChild which is in context.global"
+      },
+      {
+        name:     "Verify leading dot path not affected in global mode",
+        source:   "{#people}{.name} is {?.age}{.age} years old.{:else}not telling us their age.{/age}{/people}",
+        options: {pathScope: "global"},
+        context:  {
+             "name": "List of people",
+             "age": "8 hours",
+             "people": [
+               { "name": "Alice" },
+               { "name": "Bob", "age": 42 },
+              ]
+        },
+        expected: "Alice is not telling us their age.Bob is 42 years old.",
+        message: "should test the leading dot behavior preserved"
+     },
+     {
+        name: "Standard dotted path with falsey value. Issue 317",
+        source: "{foo.bar}",
+        options: {pathScope: "global"},
+        context: { foo: {bar: 0} },
+        expected: "0",
+        message: "should work when value at end of path is falsey"
+     },
+     {
+        name: "dotted path resolution up context",
+        source: "{#data.A.list}Aname{data.A.name}{/data.A.list}",
+        options: {pathScope: "global"},
+        context: { "data":{"A":{"name":"Al","list":[{"name": "Joe"},{"name": "Mary"}],"B":{"name":"Bob","Blist":["BB1","BB2"]}}} },
+        expected: "AnameAlAnameAl",
+        message: "should test usage of dotted path resolution up context"
+     },
+     {
+        name: "dotted path resolution up context 2",
+        source: "{#data.A.B.Blist}Aname{data.A.name}{/data.A.B.Blist}",
+        options: {pathScope: "global"},
+        context: { "data":{"A":{"name":"Al","list":[{"name": "Joe"},{"name": "Mary"}],"B":{"name":"Bob","Blist":["BB1","BB2"]}}} },
+        expected: "AnameAlAnameAl",
+        message: "should test usage of dotted path resolution up context"
+      },
+      {
+        name: "dotted path resolution without explicit context",
+        source: "{#data.A}Aname{name}{data.C.name}{/data.A}",
+        options: {pathScope: "global"},
+        context: { "data":{"A":{"name":"Al","list":[{"name": "Joe"},{"name": "Mary"}],"B":{"name":"Bob","Blist":["BB1","BB2"]}},C:{name:"cname"}} },
+        expected: "AnameAlcname",
+        message: "should test usage of dotted path resolution up context"
+      },
+      {
+        name: "same as previous test but with explicit context",
+        source: "{#data.A:B}Aname{name}{data.C.name}{/data.A}",
+        options: {pathScope: "global"},
+        context: { "data":{"A":{"name":"Al","list":[{"name": "Joe"},{"name": "Mary"}],"B":{"name":"Bob","Blist":["BB1","BB2"]}},C:{name:"cname"}} },
+        expected: "AnameAl",
+        message: "should test explicit context blocks looking further up stack"
+      },
+      {
+        name: "explicit context but gets value from global",
+        source: "{#data.A:B}Aname{name}{glob.globChild}{/data.A}",
+        options: {pathScope: "global"},
+        base: { glob: { globChild: "testGlobal"} },
+        context: { "data":{"A":{"name":"Al","list":[{"name": "Joe"},{"name": "Mary"}],"B":{"name":"Bob","Blist":["BB1","BB2"]}},C:{name:"cname"}} },
+        expected: "AnameAltestGlobal",
+        message: "should test access global despite explicit context"
+      },
+      {
+        name: "nested dotted path resolution",
+        source: "{#data.A.list}{#data.A.B.Blist}{.}Aname{data.A.name}{/data.A.B.Blist}{/data.A.list}",
+        options: {pathScope: "global"},
+        context: { "data":{"A":{"name":"Al","list":[{"name": "Joe"},{"name": "Mary"}],"B":{"name":"Bob","Blist":["BB1"]}}} },
+        expected: "BB1AnameAlBB1AnameAl",
+        message: "should test nested usage of dotted path resolution"
+      },
+      {
+        name: "check nested ref in global works in global mode",
+        source: "{glob.globChild}",
+        options: {pathScope: "global"},
+        base: { glob: { globChild: "testGlobal"} },
+        context: { },
+        expected: "testGlobal",
+        message: "Should find glob.globChild which is in context.global"
+      },
+      {
+          name: "dotted path resolution up context with partial match in current context",
+          source: "{#data}{#A}{C.name}{/A}{/data}",
+          options: {pathScope: "global"},
+          context: { "data":{ "A":{ "name":"Al", "B": "Ben", "C": { namex: "Charlie"} }, C: {name: "Charlie Sr."} } },
+          expected: "",
+          message: "should test usage of dotted path resolution up context"
+       },
+       {
+        name: "check nested ref not found in global if partial match",
+        source: "{#data}{#A}{C.name}{/A}{/data}",
+        options: {pathScope: "global"},
+        base: { C: {name: "Big Charlie"} },
+        context: { "data":{ "A":{ "name":"Al", "B": "Ben", "C": { namex: "Charlie"} }, C: {namey: "Charlie Sr."} } },
+        expected: "",
+        message: "Should find glob.globChild which is in context.global"
+      },
+      {
+        name:     "method invocation",
+        source:   "Hello {person.fullName}",
+        options: {pathScope: "global"},
+        context:  {
+          person: {
+            firstName: "Peter",
+            lastName:  "Jones",
+            fullName: function() { 
+                return this.firstName + ' ' + this.lastName; 
+            }
+          }
+        },
+        expected: "Hello Peter Jones",
+        message:  "should test resolve correct 'this' when invoking method"
+      }
+    ]
+  },
+  {
+    name: "filter tests",
+    tests: [
+      {
+        name:     "filter",
+        source:   "{#filter}foo {bar}{/filter}",
+        context:  {
+                    filter: function(chunk, context, bodies) {
+                      return chunk.tap(function(data) {
+                        return data.toUpperCase();
+                      }).render(bodies.block, context).untap();
+                    },
+
+                    bar: "bar"
+                  },
+        expected: "FOO BAR",
+        message: "should test the filter tag"
+      },
+      {
+        name:     "invalid filter",
+        source:   "{obj|nullcheck|invalid}",
+        context:  { obj: "test" },
+        expected: "test",
+        message: "should fail gracefully for invalid filter"
+      },
+      {
+        name:     "escapeJs filter without DQ",
+        source:   "{obj|j|s}",
+        context:  { obj: "<script>\\testBS\\ \rtestCR\r \u2028testLS\u2028 \u2029testPS\u2029 \ntestNL\n \ftestLF\f 'testSQ' \ttestTB\t /testFS/</script>" },
+        expected: "<script>\\\\testBS\\\\ \\rtestCR\\r \\u2028testLS\\u2028 \\u2029testPS\\u2029 \\ntestNL\\n \\ftestLF\\f \\'testSQ\\' \\ttestTB\\t \\/testFS\\/<\\/script>",
+        message: "should escapeJs a string when using the j filter"
+      },
+      {
+        name:     "escapeJs filter with only DQ",
+        source:   "{obj|j|s}",
+        context:  { obj: '"testDQ"' },
+        expected: '\\"testDQ\\"',
+        message: "should escapeJs a string with double quotes when using the j filter"
+      },
+      {
+        name:     "JSON.stringify filter",
+        source:   "{obj|js|s}",
+        context:  { obj: { id: 1, name: "bob", occupation: "construction" } },
+        expected: JSON.stringify({ id: 1, name: "bob", occupation: "construction" }),
+        message: "should stringify a JSON literal when using the js filter"
+      },
+      {
+        name:     "JSON.parse filter",
+        source:   "{obj|jp}",
+        context:  { obj: JSON.stringify({ id: 1, name: "bob", occupation: "construction" }) },
+        expected: JSON.parse(JSON.stringify({ id: 1, name: "bob", occupation: "construction" })).toString(),
+        message: "should objectify a JSON string when using the jp filter"
+      }
+    ]
+  },
+  { 
+    name: "partial definitions",
+    tests: [
+      {
+        name:     "partial",
+        source:   "Hello {name}! You have {count} new messages.",
+        context:  { name: "Mick", count: 30 },
+        expected: "Hello Mick! You have 30 new messages.",
+        message: "should test a basic replace in a template"
+      },
+      {
+        name:     "partial_with_blocks",
+        source:   "{+header}default header {/header}Hello {name}! You have {count} new messages.",
+        context:  { name: "Mick", count: 30 },
+        expected: "default header Hello Mick! You have 30 new messages.",
+        message: "should test a block with defaults"
+      },
+      {
+        name:     "partial_with_blocks_and_no_defaults",
+        source:   "{+header/}Hello {name}! You have {count} new messages.",
+        context:  { name: "Mick", count: 30 },
+        expected: "Hello Mick! You have 30 new messages.",
+        message: "should test a blocks with no defaults"
+      },
+      {
+        name:     "partial_print_name",
+        source:   "{#helper}{/helper}",
+        context:  {},
+        expected: "",
+        message: "should test a template with missing helper"
+      },
+      {
+        name:     "nested_partial_print_name",
+        source:   "{>partial_print_name/}",
+        context:  {},
+        expected: "",
+        message: "should test a template with missing helper"
+      },
+      {
+        name:     "nested_nested_partial_print_name",
+        source:   "{>nested_partial_print_name/}",
+        context:  {},
+        expected: "",
+        message: "should test nested partial"
+      }
+    ]
+  },
+  {
+    name: "partial/params tests",
+    tests : [
+      {
+        name:     "partials",
+        source:   '{>partial/} {>"hello_world"/} {>"{ref}"/}',
+        context:  { name: "Jim", count: 42, ref: "hello_world" },
+        expected: "Hello Jim! You have 42 new messages. Hello World! Hello World!",
+        message:  "should test partials"
+      },
+      {
+        name:     "partial with context",
+        source:   "{>partial:.profile/}",
+        context:  { profile: { name: "Mick", count: 30 } },
+        expected: "Hello Mick! You have 30 new messages.",
+        message:  "should test partial with context"
+      },
+      {
+        name:     "partial with blocks, with no default values for blocks",
+        source:   '{>partial_with_blocks_and_no_defaults/}',
+        context:  { name: "Mick", count: 30 },
+        expected: "Hello Mick! You have 30 new messages.",
+        message:  "partial with blocks, with no default values for blocks"
+      },
+      {
+        name:     "partial with blocks, with no default values for blocks, but override default values with inline partials",
+        source:   '{>partial_with_blocks_and_no_defaults/}{<header}override header {/header}',
+        context:  { name: "Mick", count: 30 },
+        expected: "override header Hello Mick! You have 30 new messages.",
+        message:  "partial with blocks, with no default values for blocks, but override default values with inline partials"
+      },
+      {
+        name:     "partial with blocks, override default values with inline partials",
+        source:   '{>partial_with_blocks/}{<header}my header {/header}',
+        context:  { name: "Mick", count: 30 },
+        expected: "my header Hello Mick! You have 30 new messages.",
+        message: "partial with blocks, override default values with inline partials"
+      },
+      {
+        name:     "partial with inline params",
+        source:   '{>partial name=n count="{c}"/}',
+        context:  { n: "Mick", c: 30 },
+        expected: "Hello Mick! You have 30 new messages.",
+        message: "should test partial with inline params"
+      },
+      {
+        name:     "partial with inline params tree walk up",
+        source:   '{#a}{#b}{#c}{#d}{>partial name=n count="{x}"/}{/d}{/c}{/b}{/a}',
+        context:  { n: "Mick", x: 30, a:{b:{c:{d:{e:"1"}}}} },
+        expected: "Hello Mick! You have 30 new messages.",
+        message: "should test partial with inline params tree walk up"
+      },
+      {
+        name:     "partial with inline params and context",
+        source:   '{>partial:profile name="{n}" count="{c}"/}',
+        context:  { profile:  { n: "Mick", c: 30 } },
+        expected: "Hello Mick! You have 30 new messages.",
+        message: "should test partial with inline params and context"
+      },
+      {
+        name:     "partial with inline params and context tree walk up",
+        source:   '{#profile}{#a}{#b}{#c}{#d}{>partial:profile name=n count="{x}"/}{/d}{/c}{/b}{/a}{/profile}',
+        context:  { profile:{ n: "Mick", x: 30, a:{b:{c:{d:{e:"1"}}}} } },
+        expected: "Hello Mick! You have 30 new messages.",
+        message: "should test partial with inline params and context tree walk up"
+      },
+      {
+        name:     "partial with literal inline param and context",
+        source:   '{>partial:profile name="Joe" count="99"/}',
+        context:  { profile:  { n: "Mick", count: 30 } },
+        expected: "Hello Joe! You have 30 new messages.",
+        message: "should test partial with literal inline param and context. Fallback values for name or count are undefined"
+      },
+      {
+        name:     "partial with blocks and inline params",
+        source:   '{>partial_with_blocks name=n count="{c}"/}',
+        context:  { n: "Mick", c: 30 },
+        expected: "default header Hello Mick! You have 30 new messages.",
+        message: "should test partial with blocks and inline params"
+      },
+      {
+        name:     "partial with blocks, override default values for blocks and inline params",
+        source:   '{>partial_with_blocks name=n count="{c}"/}{<header}my header {/header}',
+        context:  { n: "Mick", c: 30 },
+        expected: "my header Hello Mick! You have 30 new messages.",
+        message: "should test partial with blocks, override default values for blocks and inline params"
+      },
+      {
+        name:     "partial with blocks and no defaults, override default values for blocks and inline params",
+        source:   '{>partial_with_blocks_and_no_defaults name=n count="{c}"/}{<header}my header {/header}',
+        context:  { n: "Mick", c: 30 },
+        expected: "my header Hello Mick! You have 30 new messages.",
+        message: "should test partial blocks and no defaults, override default values for blocks and inline params"
+      },
+      {
+        name:     "partial with no blocks, ignore the override inline partials",
+        source:   '{>partial name=n count="{c}"/}{<header}my header {/header}',
+        context:  { n: "Mick", c: 30 },
+        expected: "Hello Mick! You have 30 new messages.",
+        message: "should test partial with no blocks, ignore the override inline partials"
+      },
+      {
+        name:     "partial prints the current template name",
+        source:   '{>partial_print_name/}',
+        context:  { "helper": function(chunk, context, bodies, params) 
+                      {
+                       var len = Object.keys(context.global.__templates__).length;
+                        // top of the current stack
+                      currentTemplateName = context.global.__templates__[len - 1];
+                        return chunk.write(currentTemplateName);
+                      }
+                  },
+        expected: "partial_print_name",
+        message: "should print the current template name"
+      },
+      {
+        name:     "nested partial prints the current template name",
+        source:   '{>nested_partial_print_name/}',
+        context:  { "helper": function(chunk, context, bodies, params) 
+                        {
+                         var len = Object.keys(context.global.__templates__).length;
+                          // top of the current stack
+                        currentTemplateName = context.global.__templates__[len - 1];
+                          return chunk.write(currentTemplateName);
+                        }
+                    },
+        expected: "partial_print_name",
+        message: "should print the current template name"
+      },
+      {
+        name:     "partial with makeBase_missing_global",
+        source:   '{#helper template="partial"}{/helper}',
+        context:  { "helper": function(chunk, context, bodies, params)
+                     {
+                      var newContext = {};
+                      return chunk.partial(params.template, dust.makeBase(newContext));
+                      } 
+                  },
+        expected: "Hello ! You have  new messages.",
+        message: "should render the helper with missing global context"
+      },
+    ]
+  },
+  {
+    name: "inline params tests",
+    tests: [
+      {
+        name:     "params",
+        source:   "{#helper foo=\"bar\"/}",
+        context:  {
+                    helper: function(chunk, context, bodies, params) {
+                      return chunk.write(params.foo);
+                    }
+                  },
+        expected: "bar",
+        message: "should test inner params"
+      },
+      {
+        name:     "inline params as integer",
+        source:   "{#helper foo=10 /}",
+        context:  { helper: function(chunk, context, bodies, params) { return chunk.write(params.foo); } },
+        expected: "10",
+        message: "Block handlers syntax should support integer number parameters"
+      },
+      {
+        name:     "inline params as float",
+        source:   "{#helper foo=3.14159 /}",
+        context:  { helper: function(chunk, context, bodies, params) { return chunk.write(params.foo); } },
+        expected: "3.14159",
+        message: "Block handlers syntax should support decimal number parameters"
+      }
+    ]
+  },
+  {
+    name: "inline partial/block tests",
+    tests: [
+      {  
+        name: "blocks with dynamic keys",
+        source: ['{<title_A}',
+                    'AAA',
+                  '{/title_A}',
+                  '{<title_B}',
+                    'BBB',
+                  '{/title_B}',
+                  '{+"title_{val}"/}'].join("\n"),
+        context: { "val" : "A" },
+        expected: "AAA",
+        message: "should test blocks with dynamic keys"
+      },
+      {
+        name: "blocks with more than one dynamic keys",
+        source: ['{<title_A}',
+                    'AAA',
+                  '{/title_A}',
+                  '{<title_B}',
+                    'BBB',
+                  '{/title_B}',
+                  '{+"{val1}_{val2}"/}'].join("\n"),
+        context: { "val1" : "title", "val2" : "A" },
+        expected: "AAA",
+        message: "should test blocks with more than one dynamic keys"
+      },
+      {
+        name: "blocks with dynamic key values as objects",
+        source: ['{<title_A}',
+                    'AAA',
+                  '{/title_A}',
+                  '{<title_B}',
+                    'BBB',
+                  '{/title_B}',
+                  '{+"{val1}_{obj.name}"/}'].join("\n"),
+        context: { "val1" : "title", "val2" : "A", "obj" : { "name" : "B" } },
+        expected: "BBB",
+        message: "should test blocks with dynamic key values as objects"
+      },
+      {
+        name: "blocks with dynamic key values as arrays",
+        source: ['{<title_A}',
+                    'AAA',
+                  '{/title_A}',
+                  '{<title_B}',
+                    'BBB',
+                  '{/title_B}',
+                  '{+"{val1}_{obj.name[0]}"/}'].join("\n"),
+        context: { "val1" : "title", "val2" : "A", "obj" : { "name" : ["A", "B"] } },
+        expected: "AAA",
+        message: "should test blocks with dynamic key values as arrays"
+      }
+    ]
+  },
+  {
+    name: "lambda tests",
+    tests: [
+      {
+        name: "test that the scope of the function is correct and that a non-chunk return value is used for truthiness checks",
+        source: "Hello {#foo}{#bar}{.}{/bar}{/foo} World!",
+        context: {
+                   foo: {
+                     foobar: 'Foo Bar',
+                     bar: function () {
+                       return this.foobar;
+                     }
+                   }
+                 },
+        expected: "Hello Foo Bar World!",
+        message: "should test scope of context function"
+      },
+      {
+        name: "test that function that do not return chunk and return falsy are treated as falsy",
+        source: "{#bar}{.}{:else}false{/bar}",
+        context: {
+                   bar: function () {
+                     return false;
+                   }
+                 },
+        expected: "false",
+        message: "should functions that return false are falsy"
+      },
+      {
+        name: "test that function that do not return chunk and return 0 are treated as truthy (in the Dust sense)",
+        source: "{#bar}{.}{:else}false{/bar}",
+        context: {
+                   bar: function () {
+                     return 0;
+                   }
+                 },
+        expected: "0",
+        message: "should functions that return 0 are truthy"
+      },
+      {
+        name:     "test that the scope of the function is correct",
+        source:   "Hello {#foo}{bar}{/foo} World!",
+        context:  {
+                    foo: {
+                      foobar: 'Foo Bar',
+                      bar: function () {
+                        return this.foobar;
+                      }
+                    }
+                  },
+        expected: "Hello Foo Bar World!",
+        message: "should test scope of context function"
+      },
+      {
+          name:     "test that function returning object is resolved",
+          source:   "Hello {#foo}{bar}{/foo} World!",
+          context:  {
+                      foo: {
+                        foobar: 'Foo Bar',
+                        bar: function () {
+                          return this.foobar;
+                        }
+                      }
+                    },
+          expected: "Hello Foo Bar World!",
+          message: "should test scope of context function"
+        }
+    ]
+  },
+  {
+    name: "core-grammar tests",
+    tests: [
+      {
+        name:     "ignore extra whitespaces between opening brace plus any of (#,?,@,^,+,%) and the tag identifier",
+        source:   '{# helper foo="bar" boo="boo" } {/helper}',
+        context:  { "helper": function(chunk, context, bodies, params) { return chunk.write(params.boo + " " + params.foo); } },
+        expected: "boo bar",
+        message: "should ignore extra whitespaces between opening brace plus any of (#,?,@,^,+,%) and the tag identifier"
+      },
+      {
+        name:     "error: whitespaces between the opening brace and any of (#,?,@,^,+,%) is not allowed",
+        source:   '{ # helper foo="bar" boo="boo" } {/helper}',
+        context:  { "helper": function(chunk, context, bodies, params) { return chunk.write(params.boo + " " + params.foo); } },
+        error: 'Expected buffer, comment, partial, reference, section or special but "{" found. At line : 1, column : 1',
+        message: "should show an error for whitespces between the opening brace and any of (#,?,@,^,+,%)"
+      },
+      {
+        name:     "whitespaces between the closing brace plus slash and the tag identifier is supported",
+        source:   '{# helper foo="bar" boo="boo"} {/ helper }',
+        context:  { "helper": function(chunk, context, bodies, params) { return chunk.write(params.boo + " " + params.foo); } },
+        expected: "boo bar",
+        message: "should ignore extra whitespaces between the closing brace plus slash and the tag identifier"
+      },
+      {
+        name:     "error: whitespaces between the openning curly brace and forward slash in the closing tags not supported",
+        source:   '{# helper foo="bar" boo="boo"} { / helper }',
+        context:  { "helper": function(chunk, context, bodies, params) { return chunk.write(params.boo + " " + params.foo); } },
+        error:    'Expected end tag for helper but it was not found. At line : 1, column : 32',
+        message: "should show an error because whitespaces between the '{' and the forward slash are not allowed in the closing tags"
+      },
+      {
+        name:     "whitespaces before the self closing tags is allowed",
+        source:   '{#helper foo="bar" boo="boo" /}',
+        context:  { "helper": function(chunk, context, bodies, params) { return chunk.write(params.boo + " " + params.foo); } },
+        expected: "boo bar",
+        message: "should ignore extra whitespaces before the self closing tags"
+      },
+      {
+        name:     "error: whitespaces between the forward slash and the closing brace in self closing tags",
+        source:   '{#helper foo="bar" boo="boo" / }',
+        context:  { "helper": function(chunk, context, bodies, params) { return chunk.write(params.boo + " " + params.foo); } },
+        error: 'Expected buffer, comment, partial, reference, section or special but "{" found. At line : 1, column : 1',
+        message: "should show an error for whitespaces  etween the forward slash and the closing brace in self closing tags"
+      },
+      {
+        name: "extra whitespaces between inline params supported",
+        source: '{#helper foo="bar"   boo="boo"/}',
+        context: { "helper": function(chunk, context, bodies, params) { return chunk.write(params.boo + " " + params.foo); } },
+        expected: "boo bar",
+        message: "should ignore extra whitespaces between inline params"
+      },
+      {
+        name: "error : whitespaces between the '{' plus '>' and partial identifier is not supported",
+        source: '{ > partial/} {> "hello_world"/} {> "{ref}"/}',
+        context: { "name": "Jim", "count": 42, "ref": "hello_world" },
+        error: 'Expected buffer, comment, partial, reference, section or special but "{" found. At line : 1, column : 1',
+        message: "should show an error for whitespaces between the '{' plus '>' and partial identifier"
+      },
+      {
+        name: "whitespaces before the forward slash and the closing brace in partials supported",
+        source: '{>partial /} {>"hello_world" /} {>"{ref}" /}',
+        context: { "name": "Jim", "count": 42, "ref": "hello_world" },
+        expected: "Hello Jim! You have 42 new messages. Hello World! Hello World!",
+        message: "should ignore extra whitespacesbefore the forward slash and the closing brace in partials"
+      },
+      {
+        name: "ignore whitespaces also means ignoring eol",
+        source: ['{#authors ',
+                  'name="theAuthors"',
+                  'lastname="authorlastname" ',
+                  'maxtext=300}',
+                  '{>"otherTemplate"/}',
+                  '{/authors}'].join("\n"),
+        context: {},
+        expected: "",
+        message: "should ignore eol"
+      },
+      {
+        name: "ignore carriage return or tab in inline param values",
+        source: ['{#helper name="Dialog" config="{',
+                '\'name\' : \'index\' }',
+                ' "} {/helper}'].join("\n"),
+        context: {},
+        expected: "",
+        message: "should ignore carriage return or tab in inline param values"
+      },
+       {
+        name: "support dash in key/reference",
+        source: 'Hello {first-name}, {last-name}! You have {count} new messages.',
+        context: { "first-name": "Mick", "last-name" : "Jagger", "count": 30 },
+        expected: "Hello Mick, Jagger! You have 30 new messages.",
+        message: "should test using dash in key/reference"
+      },
+      {
+        name: "support dash in partial's key",
+        source: '{<title-a}foo-bar{/title-a}{+"{foo-title}-{bar-letter}"/}',
+        context: { "foo-title" : "title", "bar-letter": "a" },
+        expected: "foo-bar",
+        message: "should test dash in partial's keys"
+      },
+      {
+        name: "support dash in partial's params",
+        source: '{>partial name=first-name count="{c}"/}',
+        context: { "first-name": "Mick", "c": 30 },
+        expected: "Hello Mick! You have 30 new messages.",
+        message: "should test dash in partial's params"
+      },
+      {
+        name: "support dash in # sections",
+        source:   "{#first-names}{name}{/first-names}",
+        context:  { "first-names": [ { name: "Moe" }, { name: "Larry" }, { name: "Curly" } ] },
+        expected: "MoeLarryCurly",
+        message: "should test dash in # sections"
+      },
+      {
+        name:     "support dash in a referece for exists section",
+        source:   "{?tags-a}tag found!{:else}No Tags!{/tags-a}" ,
+        context:  { "tags-a": "tag" },
+        expected: "tag found!",
+        message: "should test for dash in a referece for exists section"
+      },
+      { name:     "base_template with dash in the reference",
+        source:   "Start{~n}"       +
+                  "{+title-t}"        +
+                  "Template Title"    +
+                  "{/title-t}"        +
+                  "{~n}"            +
+                  "{+main-t}"         +
+                  "Template Content"  +
+                  "{/main-t}"         +
+                  "{~n}"            +
+                  "End",
+        context:  {},
+        expected: "Start\nTemplate Title\nTemplate Content\nEnd",
+        message: "should test base template with dash in the reference"
+      },
+      {
+        name:     "child_template with dash in the reference",
+        source:   "{^xhr-n}tag not found!{:else}tag found!{/xhr-n}",
+        context:  {"xhr": false},
+        expected: "tag not found!",
+        message: "should test child template with dash"
+      }
+    ]
+  },
+  {
+    name: "syntax error tests",
+    tests: [
+      {
+        name: "Dust syntax error",
+        source: "RRR {##}",
+        context: { name: "Mick", count: 30 },
+        error: 'Expected buffer, comment, partial, reference, section or special but "{" found. At line : 1, column : 5',
+        message: "should test that the error message shows line and column."
+      },
+      {
+        name: "Dust syntax error. Error in Section",
+        source: ["{#s}",
+                "{#&2}",
+                "{/s}"].join("\n"),
+        context: {},
+        error: 'Expected end tag for s but it was not found. At line : 2, column : 1',
+        message: "should test the errors message for section with error."
+      },
+      {
+        name: "Dust syntax error. Error in Section with buffer",
+        source: ["{#s}",
+                "this is the",
+                "buffer",
+                "{#&2}",
+                "a second",
+                "buffer",
+                "{/s}"].join("\n"),
+        context: {},
+        error: 'Expected end tag for s but it was not found. At line : 4, column : 1',
+        message: "should test the errors message for section with a buffer and error inside."
+      },
+      {
+        name: "Dust syntax error. Error in Section without end tag",
+        source: ["{#s}",
+                "this is the",
+                "buffer",
+                "a second",
+                "buffer"].join("\n"),
+        context: {},
+        error: 'Expected end tag for s but it was not found. At line : 5, column : 7',
+        message: "should test the errors message for section without end tag shows."
+      },
+      {
+        name: "Dust syntax error. Error in Partial with buffer",
+        source: ["{+header}",
+                "this is a Partial",
+                "with Error",
+                "eeee{@#@$fdf}",
+                "default header ",
+                "{/header}"].join("\n"),
+        context: {},
+        error: 'Expected end tag for header but it was not found. At line : 4, column : 5',
+        message: "should test the errors message for partials with a buffer inside."
+      },
+      {
+        name: "Dust syntax error. Error in Partial without end tag",
+        source: ["{+header}",
+                "this is the",
+                "buffer",
+                "a second",
+                "buffer"].join("\n"),
+        context: {},
+        error: 'Expected end tag for header but it was not found. At line : 5, column : 7',
+        message: "should test the errors message for partial without end tag."
+      },
+      {
+        name: "Dust syntax error. Error in Scalar",
+        source:["{#scalar}",
+                "true",
+                " {#@#fger}",
+                "{:else}",
+                "false",
+                "{/scalar}"].join("\n"),
+        context: {},
+        error: 'Expected end tag for scalar but it was not found. At line : 3, column : 2',
+        message: "should test the errors message for Scalar."
+      },
+      {
+        name: "Dust syntax error. Error in Scalar's else",
+        source:["{#scalar}",
+                "true",
+                "{:else}",
+                "false",
+                " {#@#fger}",
+                "{/scalar}"].join("\n"),
+        context: {},
+        error: 'Expected end tag for scalar but it was not found. At line : 5, column : 2',
+        message: "should test the errors message for Scalar."
+      },
+      {
+        name: "Dust syntax error. Error in Conditional",
+        source:["{?tags}",
+                  "<ul>{~n}",
+                    "{#tags}{~s}", 
+                      "<li>{#@$}</li>{~n}",
+                    "{/tags}",
+                  "</ul>",
+                "{:else}",
+                  "No Tags!",
+                "{/tags}"].join("\n"),
+        context: {},
+        error: 'Expected end tag for tags but it was not found. At line : 4, column : 5',
+        message: "should test the errors message for Conditionals."
+      },
+      {
+        name: "Dust syntax error. Error in Conditional's else",
+        source:["{?tags}",
+                  "<ul>{~n}",
+                    "{#tags}{~s}", 
+                      "<li>{.}</li>{~n}",
+                    "{/tags}",
+                  "</ul>",
+                "{:else}",
+                  "{#@$}",
+                  "No Tags!",
+                "{/tags}"].join("\n"),
+        context: {},
+        error: 'Expected end tag for tags but it was not found. At line : 8, column : 1',
+        message: "should test the errors message for Conditional's else."
+      },
+      {
+        name: "Dust syntax error. Error in Conditional without end tag",
+        source:["{?tags}",
+                  "<ul>{~n}",
+                    "{#tags}{~s}", 
+                      "<li>{.}</li>{~n}",
+                    "{/tags}",
+                  "</ul>",
+                "{:else}",
+                  "No Tags!"].join("\n"),
+        context: {},
+        error: 'Expected end tag for tags but it was not found. At line : 8, column : 9',
+        message: "should test the errors message for Conditional without end tag."
+      }
+    ]
+  },
+  {
+    name: "buffer test",
+    tests: [
+      {
+        name: "buffer ",
+        source: "{&partial/}",
+        context: {},
+        expected: "{&partial/}",
+        message: "given content should be parsed as buffer"
+      }
+    ]
+  },
+  {
+    name:"invalid helper test",
+    tests: [
+      {
+        name:     "non-existing helper",
+        source:   "some text {@notfound}foo{/notfound} some text",
+        context:  {},
+        expected: "some text  some text",
+        message: "Should not crash the application if an helper is not found"
+      }
+    ]
+  }
+];
+
+if (typeof module !== "undefined" && typeof require !== "undefined") {
+    module.exports = coreTests; // We're on node.js
+} else {
+    window.coreTests = coreTests; // We're on the browser
+}

--- a/test/dust_files/helpersTests.js
+++ b/test/dust_files/helpersTests.js
@@ -1,0 +1,1214 @@
+var helpersTests = [
+  {
+    name: "replace",
+    tests: [
+      {
+        name:     "hello_there",
+        source:   "Hello {name}! You have {count} new messages.",
+        context:  { name: "Mick", count: 30 },
+        expected: "Hello Mick! You have 30 new messages.",
+        message: "should test a basic replace"
+      }
+    ]
+  },
+  {
+    name: "if",
+    tests: [
+      {
+        name:     "if helper with no body",
+        source:   '{@if cond="{x}<{y}"/}',
+        context:  { x: 2, y: 3 },
+        expected: "",
+        message: "should test if helper with no body and fail gracefully"
+      },
+      {
+        name:     "if helper without else",
+        source:   '{@if cond="{x}<{y}"}<div> X < Y </div>{/if}',
+        context:  { x: 2, y: 3 },
+        expected: "<div> X < Y </div>",
+        message: "should test if helper without else"
+      },
+      {
+        name:     "if helper with else block",
+        source:   '{@if cond=" \'{x}\'.length && \'{y}\'.length "}<div> X and Y exists </div>{:else}<div> X and Y does not exists </div>{/if}',
+        context:  {},
+        expected: "<div> X and Y does not exists </div>",
+        message: "should test if helper with else block"
+      },
+      {
+        name:     "if helper with else using the or condition",
+        source:   '{@if cond=" \'{x}\'.length || \'{y}\'.length "}<div> X or Y exists </div>{:else}<div> X or Y does not exists </div>{/if}',
+        context:  { x: 1},
+        expected: "<div> X or Y exists </div>",
+        message: "should test if helper with else using the or condition"
+      },
+      {
+        name:     "if helper with else using the and conditon",
+        source:   '{@if cond="( \'{x}\'.length ) && ({x}<3)"}<div> X exists and is 1 </div>{:else}<div> x is not there </div>{/if}',
+        context:  { x : 1},
+        expected: "<div> X exists and is 1 </div>",
+        message: "should test if helper with else usingt he and conditon"
+      },
+      {
+        name:     "if helper using $idx",
+        source:   '{#list}{@if cond="( {$idx} == 1 )"}<div>{y}</div>{/if}{/list}',
+        context:  { x : 1, list: [ { y: 'foo' }, { y: 'bar'} ]},
+        expected: "<div>bar</div>",
+        message: "should test the if helper using $idx"
+      }
+    ]
+  },
+  {
+    name: "math",
+    tests: [
+      {
+        name:     "math/mod helper with zero as key value",
+        source:   '<div>{@math key="0" method="mod" operand="16"/}</div>',
+        context:  {},
+        expected: "<div>0</div>",
+        message: "testing math/mod helper with zero as key value"
+      },
+      {
+         name:     "math/mod helper with zero as key value",
+         source:   '<div>{@math key="0" method="mod" operand="-16"/}</div>',
+         context:  {},
+         expected: "<div>0</div>",
+         message: "testing math/mod helper with zero as key value"
+       },
+      {
+           name:     "math/mod helper with zero as key value and operand as variable as variable without quotes",
+           source:   '<div>{@math key="0" method="mod" operand=y/}</div>',
+           context:  { y: 4},
+           expected: "<div>0</div>",
+           message: "testing math/mod helper with zero as key value and operand as variable without quotes"
+      },
+      {
+           name:     "math/mod helper with zero as key value  and operand as variable with quotes",
+           source:   '<div>{@math key="0" method="mod" operand="{y}"/}</div>',
+           context:  { y: 4},
+           expected: "<div>0</div>",
+           message: "testing math/mod helper with zero as key value  and operand as variable with quotes"
+      },
+      {
+         name:     "math/mod helper with zero as operand value",
+         source:   '<div>{@math key="0" method="mod" operand="0"/}</div>',
+         context:  {},
+         expected: "<div>NaN</div>",
+         message: "testing math/mod helper with zero as operand value"
+       },
+       {
+           name:     "math/mod helper with negative zero as operand value",
+           source:   '<div>{@math key="0" method="mod" operand="-0"/}</div>',
+           context:  {},
+           expected: "<div>NaN</div>",
+           message: "testing math/mod helper with negative zero as operand value"
+       },
+       {
+         name:     "math/divide helper with zero as key value",
+         source:   '<div>{@math key="0" method="divide" operand="16"/}</div>',
+         context:  {},
+         expected: "<div>0</div>",
+         message: "testing math/divide helper with zero as key value"
+       },
+       {
+          name:     "math/divide helper with zero as operand value",
+          source:   '<div>{@math key="0" method="divide" operand="0"/}</div>',
+          context:  {},
+          expected: "<div>NaN</div>",
+          message: "testing math/divide helper with zero as operand value"
+        },
+      {
+        name:     "math helper mod numbers",
+        source:   '<div>{@math key="16" method="mod" operand="4"/}</div>',
+        context:  {},
+        expected: "<div>0</div>",
+        message: "testing math/mod helper with two numbers"
+      },
+      {
+        name:     "math helper mod using $idx",
+        source:   '{#list}<div>{@math key="{$idx}" method="mod" operand="5"/}</div>{/list}',
+        context:  { list: [ { y: 'foo' } ]},
+        expected: "<div>0</div>",
+        message: "should test the math/mod helper using $idx"
+      },
+      {
+         name:     "math helper mod using $idx without quotes with lizt size = 2",
+         source:   '{#list}<div>{@math key="{$idx}" method="mod" operand="2"/}</div>{/list}',
+         context:  { list: [ { y: 'foo' }, { y: "bar"} ]},
+         expected: "<div>0</div><div>1</div>",
+         message: "should test the math/mod helper using $idx without quotes with lizt size = 2"
+       },
+      {
+        name:     "math helper mod using $idx without quotes",
+        source:   '{#list}<div>{@math key=$idx method="mod" operand="5"/}</div>{/list}',
+        context:  { list: [ { y: 'foo' } ]},
+        expected: "<div>0</div>",
+        message: "should test the math/mod helper using $idx without quotes"
+      },
+      {
+        name:     "math helper mod using $idx without quotes with lizt size = 2",
+        source:   '{#list}<div>{@math key=$idx method="mod" operand="2"/}</div>{/list}',
+        context:  { list: [ { y: 'foo' }, { y: "bar"} ]},
+        expected: "<div>0</div><div>1</div>",
+        message: "should test the math/mod helper using $idx without quotes with lizt size = 2"
+      },
+      {
+        name:     "math helper mod using $len",
+        source:   '{#list}<div>{@math key="{$len}" method="mod" operand="5"/}</div>{/list}',
+        context:  { list: [ { y: 'foo' } ]},
+        expected: "<div>1</div>",
+        message: "should test the math/mod helper using $len"
+      },
+      {
+        name:     "math helper mod using $len without quotes",
+        source:   '{#list}<div>{@math key=$len method="mod" operand="5"/}</div>{/list}',
+        context:  { list: [ { y: 'foo' } ]},
+        expected: "<div>1</div>",
+        message: "should test the math/mod helper using $len without quotes"
+      },
+      {
+        name:     "math helper subtract numbers",
+        source:   '<div>{@math key="16" method="subtract" operand="4"/}</div>',
+        context:  {},
+        expected: "<div>12</div>",
+        message: "testing math/subtract helper with two numbers"
+      },
+      {
+        name:     "math helper add with key as negative number",
+        source:   '<div>{@math key="-16" method="add" operand="4"/}</div>',
+        context:  {},
+        expected: "<div>-12</div>",
+        message: "testing math/add helper with key as negative number"
+      },
+      {
+        name:     "math helper subtract with key as negative number",
+        source:   '<div>{@math key="-16" method="subtract" operand="4"/}</div>',
+        context:  {},
+        expected: "<div>-20</div>",
+        message: "testing math/subtract helper with key as negative number"
+      },
+      {
+        name:     "math helper multiply with key as negative number",
+        source:   '<div>{@math key="-2" method="multiply" operand="4"/}</div>',
+        context:  {},
+        expected: "<div>-8</div>",
+        message: "testing math/multiply helper with key as negative number"
+      },
+      {
+        name:     "math helper multiply with key as negative number and variable operand without quotes",
+        source:   '<div>{@math key="-2" method="multiply" operand=y/}</div>',
+        context:  { y: 4},
+        expected: "<div>-8</div>",
+        message: "testing math/multiply helper with key as negative number  and variable operand without quotes"
+      },
+      {
+         name:     "math helper multiply with key as negative number and variable operand with quotes",
+         source:   '<div>{@math key="-2" method="multiply" operand="{y}"/}</div>',
+         context:  { y: 4},
+         expected: "<div>-8</div>",
+         message:  "testing math/multiply helper with key as negative number and variable operand with quotes"
+      },
+      {
+        name:     "math helper add negative numbers",
+        source:   '<div>{@math key="-16" method="add" operand="-4"/}</div>',
+        context:  {},
+        expected: "<div>-20</div>",
+        message: "testing math/add helper with negative numbers"
+      },
+      {
+        name:     "math helper subtract negative numbers",
+        source:   '<div>{@math key="-16" method="subtract" operand="-4"/}</div>',
+        context:  {},
+        expected: "<div>-12</div>",
+        message: "testing math/subtract helper with negative numbers"
+      },
+      {
+        name:     "math helper multiply negative numbers",
+        source:   '<div>{@math key="-0" method="multiply" operand="-4"/}</div>',
+        context:  {},
+        expected: "<div>0</div>",
+        message: "testing math/multiply helper with negative numbers"
+      },
+      {
+         name:     "math helper blah operation",
+         source:   '{@math key="-0" method="blah" operand="-4"/}',
+         context:  {},
+         expected: "",
+         message: "math helper blah operation"
+       },
+      {
+         name:     "math helper key as zero",
+         source:   '<div>{@math key="0" method="subtract" operand="0"/}</div>',
+         context:  {},
+         expected: "<div>0</div>",
+         message: "testing math helper with zero as the operand"
+      },
+      {
+          name:     "math helper zero key",
+          source:   '<div>{@math key="0" method="multiply" operand="0"/}</div>',
+          context:  {},
+          expected: "<div>0</div>",
+          message: "testing math helper with zero key"
+      },
+      {
+          name:     "math helper zero key and operand for divide",
+          source:   '<div>{@math key="0" method="divide" operand="0"/}</div>',
+          context:  {},
+          expected: "<div>NaN</div>",
+          message: "testing math helper with zero key and operand for divide"
+      },
+      {
+        name:     "math helper zero operand",
+        source:   '<div>{@math key="16" method="subtract" operand="0"/}</div>',
+        context:  {},
+        expected: "<div>16</div>",
+        message: "testing math helper with zero as the operand"
+      },
+      {
+        name:     "math helper subtract number and string",
+        source:   '<div>{@math key="16" method="subtract" operand="doh"/}</div>',
+        context:  {},
+        expected: "<div>NaN</div>",
+        message: "testing math/subtract helper with a number and a string"
+      },
+      {
+        name:     "math helper add numbers",
+        source:   '<div>{@math key="5" method="add" operand="4"/}</div>',
+        context:  {},
+        expected: "<div>9</div>",
+        message: "testing math/add helper with two numbers"
+      },
+      {
+        name:     "math helper multiply numbers",
+        source:   '<div>{@math key="5" method="multiply" operand="4"/}</div>',
+        context:  {},
+        expected: "<div>20</div>",
+        message: "testing math/multiply helper with two numbers"
+      },
+      {
+        name:     "math helper divide using variable",
+        source:   '<div>{@math key="16" method="divide" operand="{y}"/}</div>',
+        context:  { y : 4 },
+        expected: "<div>4</div>",
+        message: "testing math/divide helper with variable as operand"
+      },
+      {
+        name:     "math helper divide  with null as key and operand value",
+        source:   '<div>{@math key="{y}" method="divide" operand="{y}"/}</div>',
+        context:  { y : null},
+        expected: "<div>NaN</div>",
+        message: "testing math/divide helper with null as key and operand value"
+      },
+      {
+        name:     "math helper divide  with null as operand value",
+        source:   '<div>{@math key="16" method="divide" operand="{y}"/}</div>',
+        context:  { y : null},
+        expected: "<div>NaN</div>",
+        message: "testing math/divide helper with null as operand value"
+      },
+      {
+         name:     "math helper divide  with null as undefined value",
+         source:   '<div>{@math key="16" method="divide" operand="{y}"/}</div>',
+         context:  { y : undefined},
+         expected: "<div>NaN</div>",
+         message: "testing math/divide helper with null as undefined value"
+       },
+      {
+         name:     "math helper mod with negative 0 as operand",
+         source:   '<div>{@math key="16" method="mod" operand="{y}"/}</div>',
+         context:  { y : -0 },
+         expected: "<div>NaN</div>",
+         message: "testing math/mod helper with negative 0 as operand"
+      },
+      {
+         name:     "math helper mod with null as key and operand",
+         source:   '<div>{@math key="{y}" method="mod" operand="{y}"/}</div>',
+         context:  { y : null },
+         expected: "<div>NaN</div>",
+         message: "testing math helper mod with null as key and operand"
+      },
+      {
+         name:     "math helper divide using negative value for variable",
+         source:   '<div>{@math key="16" method="divide" operand="{y}"/}</div>',
+         context:  { y : -4 },
+         expected: "<div>-4</div>",
+         message: "testing math/divide helper using negative value for variable as operand"
+      },
+      {
+           name:     "math helper divide using key as non numeric",
+           source:   '<div>{@math key="doh" method="divide" operand="{y}"/}</div>',
+           context:  { y : 0 },
+           expected: "<div>NaN</div>",
+           message: "testing math/divide helper using key as non numeric"
+      },
+      {
+           name:     "math helper divide using 0 for variable",
+           source:   '<div>{@math key="16" method="divide" operand="{y}"/}</div>',
+           context:  { y : 0 },
+           expected: "<div>Infinity</div>",
+           message: "testing math/divide helper using 0 for variable as operand"
+       },
+      {
+          name:     "math helper divide using negative 0 for variable",
+          source:   '<div>{@math key="16" method="divide" operand="{y}"/}</div>',
+          context:  { y : -0 },
+          expected: "<div>Infinity</div>",
+          message: "testing math/divide helper using negative 0 for variable as operand"
+      },
+      {
+        name:     "math helper floor numbers",
+        source:   '<div>{@math key="16.5" method="floor"/}</div>',
+        context:  {},
+        expected: "<div>16</div>",
+        message: "testing math/floor helper with two numbers"
+      },
+      {
+        name:     "math helper ceil numbers",
+        source:   '<div>{@math key="16.5" method="ceil"/}</div>',
+        context:  {},
+        expected: "<div>17</div>",
+        message: "testing math/ceil helper with two numbers"
+      },
+      {
+        name:     "math helper round up numbers",
+        source:   '<div>{@math key="16.5" method="round"/}</div>',
+        context:  {},
+        expected: "<div>17</div>",
+        message:  "testing math/round helper rounding up with one number"
+      },
+      {
+        name:     "math helper round down numbers",
+        source:   '<div>{@math key="16.4" method="round"/}</div>',
+        context:  {},
+        expected: "<div>16</div>",
+        message:  "testing math/round helper rounding down with one number"
+      },
+      {
+        name:     "math helper abs numbers with missing key",
+        source:   '<div>{@math key="{key}" method="abs"/}</div>',
+        context:  {},
+        expected: "<div>NaN</div>",
+        message: "testing math/abs helper with missing key"
+      },
+      {
+        name:     "math helper abs numbers",
+        source:   '<div>{@math key="-16" method="abs"/}</div>',
+        context:  {},
+        expected: "<div>16</div>",
+        message: "testing math/abs helper with two numbers"
+      },
+      {
+        name:     "math helper abs numbers with null key",
+        source:   '<div>{@math key="{key}" method="abs"/}</div>',
+        context:  {key : null},
+        expected: "<div>NaN</div>",
+        message: "testing math/abs helper with null key"
+      },
+      {
+        name:     "math helper eq filter",
+        source:   '<div>{@math key="-13" method="abs"}{@eq value=13}Test is true{/eq}{/math}</div>',
+        context:  {},
+        expected: "<div>Test is true</div>",
+        message: "testing math with body helper with abs and eq"
+      },
+      {
+        name:     "math helper with body gt test else",
+        source:   '<div>{@math key="13" method="add" operand="12"}{@gt value=123}13 + 12 > 123{:else}Math is fun{/gt}{/math}</div>',
+        context:  {},
+        expected: "<div>Math is fun</div>",
+        message: "testing math with body else helper with add and gt"
+      },
+      {
+        name:     "math helper with body gt default",
+        source:   '<div>{@math key="13" method="add" operand="12"}{@gt value=123}13 + 12 > 123{/gt}{@default}Math is fun{/default}{/math}</div>',
+        context:  {},
+        expected: "<div>Math is fun</div>",
+        message: "testing math with body else helper with add and gt and default"
+      },
+      {
+        name:     "math helper with body acts like the select helper",
+        source:   '<div>{@math key="1" method="add" operand="1"}math with body is truthy{:else}else is meaningless{/math}</div>',
+        context:  {},
+        expected: "<div>math with body is truthy</div>",
+        message: "testing math with body ignores the else"
+      },
+      {
+        name:     "math helper with body acts like the select helper",
+        source:   '<div>{@math key="1" method="subtract" operand="1"}math with body is truthy even if mathout is falsy{:else}else is meaningless{/math}</div>',
+        context:  {},
+        expected: "<div>math with body is truthy even if mathout is falsy</div>",
+        message: "testing math with body ignores the else"
+      },
+      {
+        name:     "math helper empty body",
+        source:   '<div>{@math key="1" method="add" operand="2"}{/math}</div>',
+        context:  {},
+        expected: "<div></div>",
+        message: "testing math with an empty body will show what is inside empty"
+      },
+      {
+        name:     "math helper simple round down with multiply, decimal key, and integer operand",
+        source:   '<div>{@math key="10.05" method="multiply" operand="200" round="true"/}</div>',
+        context:  {},
+        expected: "<div>2010</div>",
+        message:  "testing math/round down with multiply, decimal, and integer"
+      },
+      {
+        name:     "math helper don't round down with multiply, decimal key, and integer operand",
+        source:   '<div>{@math key="10.05" method="multiply" operand="200"/}</div>',
+        context:  {},
+        expected: "<div>2010.0000000000002</div>",
+        message:  "testing math/don't round down with multiply, decimal, and integer"
+      },
+      {
+        name:     "math helper simple round up with multiply, decimal key, and integer operand",
+        source:   '<div>{@math key="0.57" method="multiply" operand="200" round="true"/}</div>',
+        context:  {},
+        expected: "<div>114</div>",
+        message:  "testing math/round up with multiply, decimal, and integer"
+      },
+      {
+        name:     "math helper don't round up with multiply, decimal key, and integer operand",
+        source:   '<div>{@math key="0.57" method="multiply" operand="200"/}</div>',
+        context:  {},
+        expected: "<div>113.99999999999999</div>",
+        message:  "testing math/don't round up with multiply, decimal, and integer"
+      }
+    ]
+  },
+  {
+    name: "eq",
+    tests: [
+      {
+        name:     "eq helper with no body",
+        source:   "{@eq key=\"foo\" value=\"foo\"/}",
+        context:  {},
+        expected: "",
+        message: "eq helper with no body silently fails with console log"
+      },
+      {
+        name:     "eq helper matching string case",
+        source:   "{@eq key=\"foo\" value=\"foo\"}equal{/eq}",
+        context:  {},
+        expected: "equal",
+        message: "eq helper matching string case"
+      },
+      {
+        name:     "eq helper non matching string case",
+        source:   "{@eq key=\"foo\" value=\"bar\"}equal{:else}bar{/eq}",
+        context:  {},
+        expected: "bar",
+        message: "eq helper non matching string case"
+      },
+      {
+         name:     "eq helper non matching string case missing else block",
+         source:   "{@eq key=\"foo\" value=\"bar\"}equal{/eq}",
+         context:  {},
+         expected: "",
+         message: "eq helper non matching string case missing else block"
+      },
+      {
+         name:     "eq helper equal boolean case",
+         source:   "{@eq key=\"true\" value=\"true\" type=\"boolean\"}equal{/eq}",
+         context:  {},
+         expected: "equal",
+         message: "eq helper equal boolean case"
+      },
+      {
+         name:     "eq helper non equal/false boolean case",
+         source:   "{@eq key=\"false\" value=\"true\" type=\"boolean\"}equal{/eq}",
+         context:  {},
+         expected: "",
+         message: "eq helper non equal boolean case"
+      },
+      {
+        name:     "eq helper without a body",
+        source:   "{@eq key=\"abc\" value=\"java\"/}",
+        context:  {},
+        expected: "",
+        message: "eq helper without a body should fail gracefully and return nothing"
+      }
+    ]
+  },
+  {
+    name: "not eq",
+    tests: [
+      {
+         name:     "not eq helper true/notequal  boolean case",
+         source:   "{@ne key=\"true\" value=\"false\" type=\"boolean\"}not equal{/ne}",
+         context:  {},
+         expected: "not equal",
+         message: "not eq helper true/notequal  boolean case"
+      },
+      {
+         name:     "not eq helper alse/equal boolean case",
+         source:   "{@ne key=\"false\" value=\"false\" type=\"boolean\"}equal{/ne}",
+         context:  {},
+         expected: "",
+         message: "not eq helper alse/equal boolean case"
+      }
+    ]
+  },
+  {
+    name: "ne",
+    tests: [
+      {
+        name:     "ne helper with no body",
+        source:   "{@ne key=\"foo\" value=\"foo\"/}",
+        context:  {},
+        expected: "",
+        message: "ne helper with no body silently fails with console log"
+      },
+      {
+        name:     "ne helper matching string case",
+        source:   "{@ne key=\"foo\" value=\"foo\"}not equal{/ne}",
+        context:  {},
+        expected: "",
+        message: "ne helper matching string case"
+      },
+      {
+        name:     "ne helper non matching string case",
+        source:   "{@ne key=\"foo\" value=\"bar\"}not equal{:else}bar{/ne}",
+        context:  {},
+        expected: "not equal",
+        message: "ne helper non matching string case"
+      },
+      {
+         name:     "ne helper non matching string case missing else block",
+         source:   "{@ne key=\"foo\" value=\"bar\"}not equal{/ne}",
+         context:  {},
+         expected: "not equal",
+         message: "ne helper non matching string case missing else block"
+       },
+      {
+         name:     "ne helper non equal numbers case",
+         source:   "{@ne key=\"3\" value=\"5\" type=\"number\"}not equal{/ne}",
+         context:  {},
+         expected: "not equal",
+         message: "ne helper non equal numbers case"
+       },
+      {
+         name:     "ne helper equal numbers case",
+         source:   "{@ne key=\"3\" value=\"3\" type=\"number\"}not equal{/ne}",
+         context:  {},
+         expected: "",
+         message: "ne helper equal numbers case"
+       },
+      {
+         name:     "ne helper non equal boolean case",
+         source:   "{@ne key=\"false\" value=\"true\" type=\"boolean\"}not equal{/ne}",
+         context:  {},
+         expected: "not equal",
+         message: "ne helper non equal boolean case"
+       },
+      {
+         name:     "ne helper equal boolean case",
+         source:   "{@ne key=\"true\" value=\"true\" type=\"boolean\"}not equal{/ne}",
+         context:  {},
+         expected: "",
+         message: "ne helper equal boolean case"
+      }
+    ]
+  },
+  {
+    name: "lt",
+    tests: [
+      {
+        name:     "lt helper with no body",
+        source:   "{@lt key=\"2\" value=\"3\" type=\"number\"/}",
+        context:  {},
+        expected: "",
+        message: "lt helper with no body silently fails with console log"
+      },
+      {
+        name:     "lt helper defaults to type number",
+        source:   "{@lt key=\"22\" value=\"33\"}22 less than 33{/lt}",
+        context:  {},
+        expected: "22 less than 33",
+        message: "lt helper will default to type number"
+      },
+      {
+        name:     "lt helper with a variable with explicit type number",
+        source:   "{@lt key=\"{a}\" value=\"33\" type=\"number\"}22 less than 33{/lt}",
+        context:  {a: 22},
+        expected: "22 less than 33",
+        message: "lt helper with a variable with explicit type number"
+      },
+      {
+        name:     "lt helper with a variable defaults to type number ( type is not mandatory)",
+        source:   "{@lt key=\"{a}\" value=\"33\"}22 less than 33{/lt}",
+        context:  {a: 22},
+        expected: "22 less than 33",
+        message: "lt helper with a variable will default to type number"
+      },
+      {
+        name:     "lt helper with a variable defaults to type number",
+        source:   "{@lt key=a value=\"33\"}22 less than 33{/lt}",
+        context:  {a: 22},
+        expected: "22 less than 33",
+        message: "lt helper with a variable will default to type number"
+      },
+      {
+        name:     "lt helper with a variable type returned as string from tap",
+        source:   "{@lt key=\"{a}\" value=\"3\"}22 less than 3, since it is string compare{/lt}",
+        context:  {a: 22},
+        expected: "22 less than 3, since it is string compare",
+        message: "lt helper with a variable type returned as string from tap"
+      },
+      {
+        name:     "lt helper with a variable type returned as int from tap",
+        source:   "{@lt key=a value=\"3\"}22 less than 3{/lt}",
+        context:  {a: 22},
+        expected: "",
+        message: "lt helper with a with a variable type returned as int from tap"
+      },
+      {
+        name:     "lt helper with a variable with type string representing int",
+        source:   "{@lt key=a value=\"33\"}22 less than 33{/lt}",
+        context:  {a:"22"},
+        expected: "22 less than 33",
+        message: "lt helper with a variable with type string representing int"
+      },
+      {
+        name:     "lt helper with a variable with type string representing float",
+        source:   "{@lt key=a value=\"33\"}22 less than 33{/lt}",
+        context:  {a:"22.33"},
+        expected: "22 less than 33",
+        message: "lt helper with a variable with type string representing float"
+      }
+    ]
+  },
+  {
+    name: "gt",
+    tests: [
+      {
+        name:     "gt helper with type string not valid case",
+        source:   "{@gt key=\"22\" value=\"3\" type=\"string\"}22 greater than 3 with type string {:else}22 not greater than 3 with type string{/gt}",
+        context:  {},
+        expected: "22 not greater than 3 with type string",
+        message: "gt helper with type string not valid case"
+      },
+      {
+        name:     "lte helper with no body",
+        source:   "{@lte key=\"2\" value=\"3\" type=\"number\"/}",
+        context:  {},
+        expected: "",
+        message: "lte helper with no body silently fails with console log"
+      },
+      {
+        name:     "gt helper with no body",
+        source:   "{@gt key=\"5\" value=\"3\" type=\"number\"/}",
+        context:  {},
+        expected: "",
+        message: "gt helper with no body silently fails with console log"
+      },
+      {
+        name:     "gte helper with no body",
+        source:   "{@gte key=\"5\" value=\"3\" type=\"number\"/}",
+        context:  {},
+        expected: "",
+        message: "gte helper with no body silently fails with console log"
+      }
+    ]
+  },
+  {
+    name: "select",
+    tests: [
+      {
+        name:     "select helper with no body",
+        source:   "{@select key=\"foo\"/}",
+        context:  {},
+        expected: "",
+        message: "select helper with no body silently fails with console log"
+      },
+      {
+        name:     "select helper with a constant string and condition eq",
+        source:   ["{@select key=\"foo\"}",
+                     "{@eq value=\"foo\"}foo{/eq}",
+                   "{/select}"
+                  ].join("\n"),
+        context:  {},
+        expected: "foo",
+        message: "should test select helper with a constant string and condition eq"
+      },
+      {
+        name:     "select helper with a variable string and condition eq",
+        source:   ["{@select key=\"{foo}\"}",
+                     "{@eq value=\"foo\"}foo{/eq}",
+                   "{/select}"
+                  ].join("\n"),
+        context:  { "foo": "foo" },
+        expected: "foo",
+        message: "should test select helper with a variable string and condition eq"
+      },
+      {
+        name:     "select helper with variable and one condition eq",
+        source:   ["{@select key=foo}",
+                     "{@eq value=10}foobar{/eq}",
+                   "{/select}"
+                  ].join("\n"),
+        context:  { foo: 10 },
+        expected: "foobar",
+        message: "should test select helper with variable and one condition eq"
+      },
+      {
+        name:     "select helper with string variable compared to a number and one condition eq",
+        source:   ["{@select key=foo}",
+                     "{@eq value=10}foobar{/eq}",
+                   "{/select}"
+                  ].join("\n"),
+        context:  { foo: 10 },
+        expected: "foobar",
+        message: "should test select helper with string variable compared to a number and one condition eq"
+      },
+      {
+        name:     "select helper with variable and one condition lt",
+        source:   ["{@select key=foo}",
+                     "{@lt value=20}foobar{/lt}",
+                   "{/select}"
+                  ].join("\n"),
+        context:  { foo: 10 },
+        expected: "foobar",
+        message: "should test select helper with variable and one condition lt"
+      },
+      {
+        name:     "select helper with one condition lte",
+        source:   ["{@select key=foo}",
+                     "{@lte value=10}foobar{/lte}",
+                   "{/select}"
+                  ].join("\n"),
+        context:  { foo: 10 },
+        expected: "foobar",
+        message: "should test select helper with one condition lte"
+      },
+      {
+        name:     "select helper with with variable and one condition lte",
+        source:   ["{@select key=foo}",
+                     "{@lte value=11}foobar{/lte}",
+                   "{/select}"
+                  ].join("\n"),
+        context:  { foo: 10 },
+        expected: "foobar",
+        message: "should test select helper with variable and one condition lte"
+      },
+      {
+        name:     "select helper with variable and one condition gt",
+        source:   ["{@select key=foo}",
+                     "{@gt value=5}foobar{/gt}",
+                   "{/select}"
+                  ].join("\n"),
+        context:  { foo: 10 },
+        expected: "foobar",
+        message: "should test select helper with variable and one condition gt"
+      },
+      {
+        name:     "select helper with variable and one condition gte",
+        source:   ["{@select key=foo}",
+                     "{@gte value=10}foobar{/gte}",
+                   "{/select}"
+                  ].join("\n"),
+        context:  { foo: 10 },
+        expected: "foobar",
+        message: "should test select helper with variable and one condition gte"
+      },
+      {
+        name:     "select helper with variable and one condition gte",
+        source:   ["{@select key=foo}",
+                     "{@gte value=5}foobar{/gte}",
+                   "{/select}"
+                  ].join("\n"),
+        context:  { foo: 10 },
+        expected: "foobar",
+        message: "should test select helper with variable and one condition gte"
+      },
+      {
+        name:     "select helper with a zero variable and one condition gte",
+        source:   ["{@select key=foo}",
+                     "{@gte value=0}foobar{/gte}",
+                   "{/select}"
+                  ].join("\n"),
+        context:  { foo: 0 },
+        expected: "foobar",
+        message: "should test select helper with variable and one condition gte"
+      },
+      {
+        name:     "select helper with variable of type string and eq condition",
+        source:   ["{@select key=\"{foo}\"}",
+                     "{@eq value=\"bar\"}foobar{/eq}",
+                   "{/select}"
+                  ].join("\n"),
+        context:  { "foo": "bar" },
+        expected: "foobar",
+        message: "should test select helper with variable of type string and eq condition"
+      },
+      {
+        name:     "select helper with two conditions",
+        source:   ["{@select key=\"{foo}\"}",
+                     "{@eq value=\"bar\"}foobar{/eq}",
+                     "{@eq value=\"baz\"}foobaz{/eq}",
+                   "{/select}"
+                  ].join("\n"),
+        context:  { "foo": "baz" },
+        expected: "foobaz",
+        message: "should test select helper works with two conditions"
+      },
+      {
+        name:     "select helper with three conditions and default case",
+        source:   ["{@select key=\"{foo}\"}",
+                     "{@eq value=\"bar\"}foobar{/eq}",
+                     "{@eq value=\"baz\"}foobaz{/eq}",
+                     "{@eq value=\"foobar\"}foofoobar{/eq}",
+                     "{@default value=\"foo\"}foofoo{/default}",
+                   "{/select}"
+                  ].join("\n"),
+        context:  { "foo": "foo" },
+        expected: "foofoo",
+        message: "should test select helper with three conditions and default case"
+      },
+      {
+        name:     "select helper with no matching conditions",
+        source:   ["{@select key=\"{foo}\"}",
+                     "{@eq value=\"bar\"}foobar{/eq}",
+                     "{@eq value=\"baz\"}foobaz{/eq}",
+                   "{/select}"
+                  ].join("\n"),
+        context:  { "foo": "foo" },
+        expected: "",
+        message: "should test select helper with no matching conditions"
+      },
+      {
+        name:     "select helper with variable and type string with 2 conditions",
+        source:   ['{@select key=test}',
+                    '{@eq value="{y}"}<div>FOO</div>{/eq}',
+                    '{@eq value="{x}"}<div>BAR</div>{/eq}',
+                  '{/select}'].join("\n"),
+        context:  { "test":"foo", "y": "foo", "x": "bar" },
+        expected: "<div>FOO</div>",
+        message: "should test select helper with variable and type string with 2 conditions"
+      },
+      {
+        name:     "select helper with variable and type string in a nested object",
+        source:   "{@select key=x.key}{@eq value=10}foobar{/eq}{/select}",
+        context:  {"x": {"key" : 10}},
+        expected: "foobar",
+        message: "should test select helper with variable and type string in a nested object"
+      },
+      {
+        name:     "select helper with variable and type string in a nested objects",
+        source:   "{@select key=\"{x.b.foo}\"}{@eq value=\"a\"}foobar{/eq}{/select}",
+        context:  { x : {b : { "foo" : "a"}}},
+        expected: "foobar",
+        message: "should test select helper with variable and type string in a nested objects"
+      },
+
+      {
+        name:     "select helper with missing key in the context and hence no output",
+        source:   ["{#b}{@select key=y}",
+                   " {@eq value=\"{z}\"}<div>FOO</div>{/eq}",
+                   " {@eq value=\"{x}\"}<div>BAR</div>{/eq}",
+                   " {@default}foofoo{/default}",
+                   "{/select}{/b}"].join("\n"),
+        context:  { b : { z: "foo", x: "bar" } },
+        expected: "",
+        message: "should test select helper with missing key in the context and hence no output"
+      },
+      {
+        name:     "select helper wih key matching the default condition",
+        source:   ["{#b}{@select key=\"{x}\"}",
+                   " {@eq value=\"{y}\"}<div>BAR</div>{/eq}",
+                   " {@eq value=\"{z}\"}<div>BAZ</div>{/eq}",
+                   " {@default value=\"foo\"}foofoo{/default}",
+                   "{/select}{/b}"].join("\n"),
+        context:  { b : { "x": "foo", "y": "bar", "z": "baz" } },
+        expected: "foofoo",
+        message: "should test select helper with key matching the default condition"
+      },
+      {
+        name:     "select helper inside a array with .",
+        source:   ["{#skills}{@select key=.}",
+                   "{@eq value=\"java\"}JAVA,{/eq}",
+                   "{@eq value=\"js\"}JS,{/eq}",
+                   "{@default value=\"foo\"}UNKNOWN{/default}",
+                   "{/select}{/skills}"].join("\n"),
+        context:  { "skills" : [ "java", "js" , "unknown"] },
+        expected: "JAVA,JS,UNKNOWN",
+        message: "should test a select helper inside a array with ."
+      },
+      {
+        name:     "select helper inside a array with {.}",
+        source:   ["{#skills}{@select key=\"{.}\"}",
+                   "{@eq value=\"java\"}JAVA,{/eq}",
+                   "{@eq value=\"js\"}JS,{/eq}",
+                   "{@default value=\"foo\"}UNKNOWN{/default}",
+                   "{/select}{/skills}"].join("\n"),
+        context:  { "skills" : [ "java", "js" , "unknown"] },
+        expected: "JAVA,JS,UNKNOWN",
+        message: "should test select helper inside a array with {.}"
+      }
+    ]
+  },
+  {
+    name: "size",
+    tests: [
+      {
+         name:     "size helper does not support body",
+         source:   'you have {@size key=list}{body}{/size} new messages',
+         context:  { list: [ 'msg1', 'msg2', 'msg3' ], "body" : "body block" },
+         expected: "you have 3 new messages",
+         message: "should test size helper not supporting body"
+       },
+      {
+        name:     "size helper 3 items",
+        source:   'you have {@size key=list/} new messages',
+        context:  { list: [ 'msg1', 'msg2', 'msg3' ] },
+        expected: "you have 3 new messages",
+        message: "should test if size helper is working properly with array"
+      },
+      {
+        name:     "size helper string",
+        source:   "'{mystring}' has {@size key=mystring/} letters",
+        context:  { mystring: 'hello' },
+        expected: "'hello' has 5 letters",
+        message: "should test if size helper is working properly with strings"
+      },
+      {
+        name:     "size helper string (empty)",
+        source:   "'{mystring}' has {@size key=mystring/} letters",
+        context:  { mystring: '' },
+        expected: "'' has 0 letters",
+        message: "should test if size helper is working properly with strings"
+      },
+      {
+        name:     "size helper for newline",
+        source:   "{@size key=mystring/} letters",
+        context:  { mystring: '\n' },
+        expected: "1 letters",
+        message: "should test if size is working for newline"
+      },
+      {
+        name:     "size helper string with newline",
+        source:   "{@size key=mystring/} letters",
+        context:  { mystring: 'test\n' },
+        expected: "5 letters",
+        message: "should test if size for string with newline"
+      },
+      {
+        name:     "size helper string with newline, tab, carriage return and bakspace",
+        source:   "{@size key=mystring/} letters",
+        context:  { mystring: 'test\n\t\r\b' },
+        expected: "8 letters",
+        message: "should test if size helper is working for string with newline, tab, carriage return and bakspace"
+      },
+      {
+        name:     "size helper number",
+        source:   'you have {@size key=mynumber/} new messages',
+        context:  { mynumber: 0 },
+        expected: "you have 0 new messages",
+        message: "should test if size helper is working properly with numeric 0"
+      },
+      {
+        name:     "size helper number",
+        source:   'you have {@size key=mynumber/} new messages',
+        context:  { mynumber: 10 },
+        expected: "you have 10 new messages",
+        message: "should test if size helper is working properly with numeric 10"
+      },
+      {
+        name:     "size helper floating numeric",
+        source:   'you have {@size key=mynumber/} new messages',
+        context:  { mynumber: 0.4 },
+        expected: "you have 0.4 new messages",
+        message: "should test if size helper is working properly with floating numeric"
+      },
+      {
+         name:     "size helper with boolean false",
+         source:   'you have {@size key=myboolean/} new messages',
+         context:  { myboolean: false },
+         expected: "you have 0 new messages",
+         message: "should test if size helper is working properly with boolean false"
+      },
+      {
+          name:     "size helper with boolean true",
+          source:   'you have {@size key=myboolean/} new messages',
+          context:  { myboolean: true },
+          expected: "you have 0 new messages",
+          message: "should test if size helper is working properly with boolean true"
+      }, 
+      {
+        name:     "size helper with object",
+        source:   'you have {@size key=myValue/} new messages',
+        context:  { myValue: { foo:'bar', baz:'bax' } },
+        expected: "you have 2 new messages",
+        message: "should test if size helper is working properly when the value is an object "
+      },
+      {
+        name:     "size helper with object",
+        source:   'you have {@size key=myValue/} new messages',
+        context:  { myValue: {} },
+        expected: "you have 0 new messages",
+        message: "should test if size helper is working properly when the value is an object that is zero"
+      },
+      {
+        name:     "size helper value not set",
+        source:   'you have {@size key=myNumber/} new messages',
+        context:  {},
+        expected: "you have 0 new messages",
+        message: "should test if size helper is working properly when the value is not present in context"
+      }
+    ]
+  },
+  {
+    name: "tap",
+    tests: [
+      {
+        name:     "tap helper: Plain text string literal",
+        source:   'plain text. {@tapper value="plain text"/}',
+        context:  {},
+        expected: "plain text. plain text",
+        message: "should test if tap helper is working properly when the value is plain text"
+      },
+      {
+        name:     "tap helper: string literal that includes a string-valued {context variable}",
+        source:   'a is {a}. {@tapper value="a is {a}"/}',
+        context:  { a : "Alpha" },
+        expected: "a is Alpha. a is Alpha",
+        message: "should test if tap helper is working properly when the value is a text that inclues a string-valued {context variable}"
+      },
+      {
+        name:     "tap helper: reference to string-valued context variable",
+        source:   '{a}. {@tapper value=a/}',
+        context:  { a : "Alpha" },
+        expected: "Alpha. Alpha",
+        message: "should test if tap helper is working properly when it makes referece to string-valued context variable"
+      },
+      {
+        name:     "tap helper: string literal that includes a string-valued {context function}",
+        source:   'b is {b}. {@tapper value="b is {b}"/}',
+        context:  { "b" : function() { return "beta"; } },
+        expected: "b is beta. b is beta",
+        message: "should test if tap helper is working properly when the value is a string literal that includes a string-valued {context function}"
+      },
+      {
+        name:     "tap helper: reference to a a string-valued {context function}",
+        source:   '{b}. {@tapper value=b/}',
+        context:  { "b" : function() { return "beta"; } },
+        expected: "beta. beta",
+        message: "should test if tap helper is working properly when it makes reference to a a string-valued {context function}"
+      },
+      {
+        name:     "tap helper: string literal that includes an object-valued {context variable}",
+        source:   'a.foo is {a.foo}. {@tapper value="a.foo is {a.foo}"/}',
+        context:  { "a" : {"foo":"bar"} },
+        expected: "a.foo is bar. a.foo is bar",
+        message: "should test if tap helper is working properly when the value is a string literal that includes an object-valued {context variable}"
+      },
+      {
+        name:     "tap helper: reference to an object-valued {context variable}",
+        source:   '{a.foo}. {@tapper value=a.foo/}',
+        context:  { "a" : {"foo":"bar"} },
+        expected: "bar. bar",
+        message: "should test if tap helper is working properly when it makes reference to an object-valued {context variable}"
+      },
+      {
+        name:     "tap helper: string literal that calls a function within an object-valued {context variable}",
+        source:   'a.foo is {a.foo}. {@tapper value="a.foo is {a.foo}"/}',
+        context:  { "a" : {"foo" : function() { return "bar"; } } },
+        expected: "a.foo is bar. a.foo is bar",
+        message: "should test if tap helper is working properly when the value is string literal that calls a function within an object-valued {context variable}"
+      },
+      {
+        name:     "tap helper: reference to a function within an object-valued {context variable}",
+        source:   '{a.foo} {@tapper value=a.foo/}',
+        context:  { "a" : {"foo" : function() { return "bar"; } } },
+        expected: "bar bar",
+        message: "should test if tap helper is working properly when it makes reference to a function within an object-valued {context variable}"
+      }
+    ]
+  },
+  {
+    name: "contextDump",
+    tests: [
+      {
+           name:     "contextDump simple test does not support body",
+           source:   "{@contextDump}{body}{/contextDump}",
+           context:  { "A" : 2, "B": 3},
+           expected: "{\n  \"A\": 2,\n  \"B\": 3\n}",
+           message: "contextDump simple test does not support body"
+      },
+      {
+          name:     "contextDump simple test",
+          source:   "{@contextDump/}",
+          context:  { "A": 2, "B": 3},
+          expected: "{\n  \"A\": 2,\n  \"B\": 3\n}",
+          message: "contextDump simple test"
+      },
+      {
+          name:     "contextDump simple test dump to console",
+          source:   "{@contextDump to=\"console\"/}",
+          context:  { "A": 2, "B": 3},
+          expected: "",
+          message: "contextDump simple test"
+      },
+      {
+          name:     "contextDump full test",
+          source:   "{@contextDump key=\"full\"/}",
+          context:  { aa: { "A": 2, "B": 3} },
+          expected: "{\n  \"isObject\": true,\n  \"head\": {\n    \"aa\": {\n      \"A\": 2,\n      \"B\": 3\n    }\n  }\n}",
+          message: "contextDump full test"
+      },
+      {
+          name:     "contextDump function dump test",
+          source:   "{#aa param=\"{p}\"}{@contextDump key=\"full\"/}{/aa}",
+          context:  { "aa": ["a"], "p" : 42},
+          expected: "{\n  \"tail\": {\n    \"tail\": {\n      \"isObject\": true,\n      \"head\": {\n        \"aa\": [\n          \"a\"\n        ],\n        \"p\": 42\n      }\n    },\n    \"isObject\": true,\n    \"head\": {\n      \"param\": \"function body_2(chk,ctx){return chk.reference(ctx.get(\\\"p\\\"),ctx,\\\"h\\\");}\",\n      \"$len\": 1,\n      \"$idx\": 0\n    }\n  },\n  \"isObject\": false,\n  \"head\": \"a\",\n  \"index\": 0,\n  \"of\": 1\n}",
+          message: "contextDump function dump test"
+      }
+    ]
+  },
+  {
+    name: "idx",
+    tests: [
+      {
+        name:     "idx helper within partial included in a array",
+        source:   '{#n}{@idx}{.}>>{/idx}{>hello_there name=. count="30"/}{/n}',
+        context:  { n: ["Mick", "Tom", "Bob"] },
+        expected: "0>>Hello Mick! You have 30 new messages.1>>Hello Tom! You have 30 new messages.2>>Hello Bob! You have 30 new messages.",
+        message: "should test idx helper within partial included in a array"
+      }
+    ]
+  },
+  {
+    name: "sep",
+    tests: [
+      {
+        name:     "sep helper within partial included in a array",
+        source:   '{#n}{>hello_there name=. count="30"/}{@sep} {/sep}{/n}',
+        context:  { n: ["Mick", "Tom", "Bob"] },
+        expected: "Hello Mick! You have 30 new messages. Hello Tom! You have 30 new messages. Hello Bob! You have 30 new messages.",
+        message: "should test sep helper within partial included in a array"
+      },
+      {
+        name:     "sep helper in a async_iterator",
+        source:   "{#numbers}{#delay}{.}{/delay}{@sep}, {/sep}{/numbers}",
+        context:  {
+                    numbers: [3, 2, 1],
+                    delay: function(chunk, context, bodies) {
+                      return chunk.map(function(chunk) {
+                       setTimeout(function() {
+                          chunk.render(bodies.block, context).end();
+                        }, Math.ceil(Math.random()*10));
+                      });
+                   }
+                  },
+        expected: "3, 2, 1",
+        message: "should sep helper in a async_iterator"
+      }
+    ]
+  }
+];
+
+if (typeof module !== "undefined" && typeof require !== "undefined") {
+    module.exports = helpersTests; // We're on node.js
+} else {
+    window.helpersTests = helpersTests; // We're on the browser
+}

--- a/test/test.html
+++ b/test/test.html
@@ -8,12 +8,10 @@
 		<script type="text/javascript" src="./dust_files/jquery.min.js"></script>
 		<script type="text/javascript" src="./dust_files/jsdump.js"></script>
 		<script type="text/javascript" src="./dust_files/beautify.js"></script>
-		<script type="text/javascript" src="https://raw.github.com/linkedin/dustjs/master/lib/dust.js"></script>
-		<script type="text/javascript" src="https://raw.github.com/linkedin/dustjs/master/lib/compiler.js"></script>
-		<script type="text/javascript" src="https://raw.github.com/linkedin/dustjs/master/lib/parser.js"></script>
-		<script type="text/javascript" src="https://raw.github.com/linkedin/dustjs-helpers/master/dist/dust-helpers-1.1.0.js"></script>
-		<script type="text/javascript" src="https://raw.github.com/linkedin/dustjs/master/test/jasmine-test/spec/coreTests.js"></script>
-		<script type="text/javascript" src="https://raw.github.com/linkedin/dustjs-helpers/master/test/jasmine-test/spec/helpersTests.js"></script>
+		<script type="text/javascript" src="https://cdn.jsdelivr.net/dustjs/2.0.2/dust-full.min.js"></script>
+		<script type="text/javascript" src="https://cdn.jsdelivr.net/dustjs.helpers/1.1.1/dust-helpers-1.1.1.js"></script>
+		<script type="text/javascript" src="./dust_files/coreTests.js"></script>
+		<script type="text/javascript" src="./dust_files/helpersTests.js"></script>
 		<script type="text/javascript" src="./dust_files/test.js"></script>
 	</head>
 	<body>


### PR DESCRIPTION
Fixing Issue #277. Too many people use Chrome to leave the test/learn page broken. Put copies of the test files directly into the dust_files folder for now. We can either updated them when we add new tests or, more likely only update them when there are significant new features to demonstrate like a new helper. For the most part, I think people look at some of these but often just prototype their dust work in the test tool so current versions of all tests is not a big deal.  One day we can pursue submodules. Tested the resultant changes in Chrome and Firefox from the local file system. Both worked fine.
