### PR TITLE
remove node_modules directory

### DIFF
--- a/node_modules/.bin/jasmine-node
+++ b/node_modules/.bin/jasmine-node
@@ -1,1 +1,0 @@
-../jasmine-node/bin/jasmine-node


### PR DESCRIPTION
This commit removes unnecessary "node_modules" directory, that is already added to git ignore and only clutters repository. This directory will be created when `npm install` is performed.
