### PR TITLE
Issue #340. Remove old optimization to avoid looking at arrays in get.

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -377,7 +377,7 @@ function getGlobal(){
 
   function Stack(head, tail, idx, len) {
     this.tail = tail;
-    this.isObject = !dust.isArray(head) && head && typeof head === 'object';
+    this.isObject = head && typeof head === 'object';
     this.head = head;
     this.index = idx;
     this.of = len;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dustjs-linkedin",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "Aleksander Williams",
   "description": "Asynchronous templates for the browser and node.js ( LinkedIn fork )",
   "contributors": [

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -638,6 +638,13 @@ var coreTests = [
         },
         expected: "22",
         message: "should test the array reference access with len and current context"
+      },
+      {
+        name: "using idx in double nested array",
+        source: "{#test}{#.}{.}i:{$idx}l:{$len},{/.}{/test}",
+        context: { "test": [[ 1,2,3 ]]},
+        expected: "1i:0l:3,2i:1l:3,3i:2l:3,",
+        message: "should test double nested array and . reference: issue #340"
       }
     ]
   },


### PR DESCRIPTION
Issue #340 

Original code (pre $idx) tried to optimize get by not checking for value when an array was at the head. With the addition of $idx, this "optimization" breaks a use case. Removing the array check when creating a Stack entry fixes the problem by allowing get to go ahead and discover the $idx value on the stack. Added a test for the reported problem.
