### PR TITLE
#300 escape all values going into compile Dust code to allow for //

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -366,9 +366,7 @@ function compileSection(context, node, cmd) {
     ')';
 }
 
-var escape = (typeof JSON === 'undefined') ?
-                function(str) { return '"' + dust.escapeJs(str) + '"';} :
-                JSON.stringify;
+var escape = function(str) { return '"' + dust.escapeJs(str) + '"';};
 
 return dust;
 

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -200,7 +200,7 @@ var coreTests = [
       {
         name:     "issue322 use base template picks up prefix chunk data",
         source:   '{>issue322 name="abc"/}' +
-		   "{<abc}ABC{/abc}",
+                  "{<abc}ABC{/abc}",
         context:  {},
         expected: "hiABC",
         message: "should use base template and honor name passed in"
@@ -686,7 +686,7 @@ var coreTests = [
     ]
   },
 /**
- * CONDITINOAL TESTS
+ * CONDITIONAL TESTS
  */
   {
     name: "conditional tests",
@@ -1659,6 +1659,13 @@ var coreTests = [
         context: {},
         expected: "{&partial/}",
         message: "given content should be parsed as buffer"
+      },
+      {
+        name: "buffer with slashes quotes etc",
+        source: "//inlineComment/*blockComment*/'single quote'\"double quote\"[bracket]\\backslash\\",
+        context: {},
+        expected: "//inlineComment/*blockComment*/'single quote'\"double quote\"[bracket]\\backslash\\",
+        message: "the compiled code should not break on commments etc"
       }
     ]
   },


### PR DESCRIPTION
Buffers, raw, literal, references etc were only going through JSON.stringify. 
They should be js escaped instead. Dust's jsescape escapes slahes and other stuff.

Issue #300 would affect places were literals, buffers or raw are used, but buffers are the most to be a problem.

for a template:

```
// inline comments
```

we want the compiled template to write

```
chk.write("\/\/ inline comments")
```

similarly  there are cases where you'll have

```
{#section param="//comment?"}
{/section}
```

```
{>"//comment"}
```

```
{`
raw blocks of code
with // comment
`}
```
