### PR TITLE
Do not hide errors

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -22,6 +22,7 @@ function getGlobal(){
       logger = EMPTY_FUNC;
 
   dust.isDebug = false;
+  dust.throwErrors = true;
   dust.debugLevel = INFO;
 
   // Try to find the console logger in window scope (browsers) or top level scope (node.js)
@@ -58,7 +59,7 @@ function getGlobal(){
    */
   dust.onError = function(error, chunk) {
     dust.log(error.message || error, ERROR);
-    if(dust.isDebug) {
+    if(dust.isDebug || dust.throwErrors) {
       throw error;
     } else {
       return chunk;


### PR DESCRIPTION
cause it may be error not in dust, but in some external callback function.
