### PR TITLE
Allowing whitespace between key-value pairs of section parameters for nicer formatting.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -505,7 +505,7 @@ var parser = (function(){
       }
       
       function parse_params() {
-        var result0, result1, result2, result3, result4;
+        var result0, result1, result2, result3, result4, result5, result6;
         var pos0, pos1, pos2;
         
         reportFailures++;
@@ -526,25 +526,47 @@ var parser = (function(){
         if (result1 !== null) {
           result2 = parse_key();
           if (result2 !== null) {
-            if (input.charCodeAt(pos.offset) === 61) {
-              result3 = "=";
-              advance(pos, 1);
-            } else {
-              result3 = null;
-              if (reportFailures === 0) {
-                matchFailed("\"=\"");
-              }
+            result3 = [];
+            result4 = parse_ws();
+            while (result4 !== null) {
+              result3.push(result4);
+              result4 = parse_ws();
             }
             if (result3 !== null) {
-              result4 = parse_number();
-              if (result4 === null) {
-                result4 = parse_identifier();
-                if (result4 === null) {
-                  result4 = parse_inline();
+              if (input.charCodeAt(pos.offset) === 61) {
+                result4 = "=";
+                advance(pos, 1);
+              } else {
+                result4 = null;
+                if (reportFailures === 0) {
+                  matchFailed("\"=\"");
                 }
               }
               if (result4 !== null) {
-                result1 = [result1, result2, result3, result4];
+                result5 = [];
+                result6 = parse_ws();
+                while (result6 !== null) {
+                  result5.push(result6);
+                  result6 = parse_ws();
+                }
+                if (result5 !== null) {
+                  result6 = parse_number();
+                  if (result6 === null) {
+                    result6 = parse_identifier();
+                    if (result6 === null) {
+                      result6 = parse_inline();
+                    }
+                  }
+                  if (result6 !== null) {
+                    result1 = [result1, result2, result3, result4, result5, result6];
+                  } else {
+                    result1 = null;
+                    pos = clone(pos2);
+                  }
+                } else {
+                  result1 = null;
+                  pos = clone(pos2);
+                }
               } else {
                 result1 = null;
                 pos = clone(pos2);
@@ -562,7 +584,7 @@ var parser = (function(){
           pos = clone(pos2);
         }
         if (result1 !== null) {
-          result1 = (function(offset, line, column, k, v) {return ["param", ["literal", k], v]})(pos1.offset, pos1.line, pos1.column, result1[1], result1[3]);
+          result1 = (function(offset, line, column, k, v) {return ["param", ["literal", k], v]})(pos1.offset, pos1.line, pos1.column, result1[1], result1[5]);
         }
         if (result1 === null) {
           pos = clone(pos1);
@@ -584,25 +606,47 @@ var parser = (function(){
           if (result1 !== null) {
             result2 = parse_key();
             if (result2 !== null) {
-              if (input.charCodeAt(pos.offset) === 61) {
-                result3 = "=";
-                advance(pos, 1);
-              } else {
-                result3 = null;
-                if (reportFailures === 0) {
-                  matchFailed("\"=\"");
-                }
+              result3 = [];
+              result4 = parse_ws();
+              while (result4 !== null) {
+                result3.push(result4);
+                result4 = parse_ws();
               }
               if (result3 !== null) {
-                result4 = parse_number();
-                if (result4 === null) {
-                  result4 = parse_identifier();
-                  if (result4 === null) {
-                    result4 = parse_inline();
+                if (input.charCodeAt(pos.offset) === 61) {
+                  result4 = "=";
+                  advance(pos, 1);
+                } else {
+                  result4 = null;
+                  if (reportFailures === 0) {
+                    matchFailed("\"=\"");
                   }
                 }
                 if (result4 !== null) {
-                  result1 = [result1, result2, result3, result4];
+                  result5 = [];
+                  result6 = parse_ws();
+                  while (result6 !== null) {
+                    result5.push(result6);
+                    result6 = parse_ws();
+                  }
+                  if (result5 !== null) {
+                    result6 = parse_number();
+                    if (result6 === null) {
+                      result6 = parse_identifier();
+                      if (result6 === null) {
+                        result6 = parse_inline();
+                      }
+                    }
+                    if (result6 !== null) {
+                      result1 = [result1, result2, result3, result4, result5, result6];
+                    } else {
+                      result1 = null;
+                      pos = clone(pos2);
+                    }
+                  } else {
+                    result1 = null;
+                    pos = clone(pos2);
+                  }
                 } else {
                   result1 = null;
                   pos = clone(pos2);
@@ -620,7 +664,7 @@ var parser = (function(){
             pos = clone(pos2);
           }
           if (result1 !== null) {
-            result1 = (function(offset, line, column, k, v) {return ["param", ["literal", k], v]})(pos1.offset, pos1.line, pos1.column, result1[1], result1[3]);
+            result1 = (function(offset, line, column, k, v) {return ["param", ["literal", k], v]})(pos1.offset, pos1.line, pos1.column, result1[1], result1[5]);
           }
           if (result1 === null) {
             pos = clone(pos1);

--- a/src/dust.pegjs
+++ b/src/dust.pegjs
@@ -50,7 +50,7 @@ context
   params is defined as matching white space followed by = and identfier or inline
 ---------------------------------------------------------------------------------------------------------------------------------------*/
 params "params"
-  = p:(ws+ k:key "=" v:(number / identifier / inline) {return ["param", ["literal", k], v]})*
+  = p:(ws+ k:key ws* "=" ws* v:(number / identifier / inline) {return ["param", ["literal", k], v]})*
   { return ["params"].concat(p) }
 
 /*-------------------------------------------------------------------------------------------------------------------------------------

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -1414,6 +1414,18 @@ var coreTests = [
         message: "should ignore extra whitespaces between inline params"
       },
       {
+        name: "extra whitespaces between key-value pairs of params supported",
+        source: '\n\
+        {#helper \n\
+          foo  = "bar"\n\
+          boo  = "boo"\n\
+          baz  = "baz"\n\
+        /}',
+        context: { "helper": function(chunk, context, bodies, params) { return chunk.write(params.boo + " " + params.foo + " " + params.baz); } },
+        expected: "boo bar baz",
+        message: "should ignore extra whitespaces between key-value pairs of params"
+      },
+      {
         name: "error : whitespaces between the '{' plus '>' and partial identifier is not supported",
         source: '{ > partial/} {> "hello_world"/} {> "{ref}"/}',
         context: { "name": "Jim", "count": 42, "ref": "hello_world" },


### PR DESCRIPTION
In cases where there are too many parameters to a section to fit on a single line, it's much easier to format the parameters using newlines an indentations. An example similar to the one in our codebase:

```dustjs
{@define_mapping name="doc_types"
    blog           = "page"
    article        = "page"
    our-clients    = "page"
    html-document  = "page"
    blob           = "page"
    event-document = "event"
    meeting        = "event"
    lecture        = "event"
    landing-page   = "sidebar-page"
    ...
/}
    
```

Instead of:

```dustjs
{@define_mapping name="doc_types" blog="page" article="page" our-clients="page" html-document="page" blob="page" event-document="event" meeting="event" lecture="event" landing-page="sidebar-page" ... /}
```
This patch extends the `params` rule in `dust.pegjs` to allow additional whitespace before and after the `=` terminal.
It also includes a test case in `coreTests.js` that uses the new formatting.