### PR TITLE
Make dust only swallow dust errors unless the dust.silenceAllErrors flag is set to true

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -7,12 +7,13 @@
       WARN = 'WARN',
       INFO = 'INFO',
       DEBUG = 'DEBUG',
-      levels = [DEBUG, INFO, WARN, ERROR, NONE, SILENT],
+      loggingLevels = [DEBUG, INFO, WARN, ERROR, NONE],
       EMPTY_FUNC = function() {},
       logger = EMPTY_FUNC,
       loggerContext = this;
 
   dust.debugLevel = NONE;
+  dust.silenceErrors = false;
 
   // Try to find the console logger in global scope
   if (root && root.console && root.console.log) {
@@ -30,10 +31,11 @@
   dust.log = function(message, type) {
     // isDebug is deprecated, so this conditional will default the debugLevel to INFO if it's set to maintain backcompat.
     if(dust.isDebug && dust.debugLevel === NONE) {
+      logger.call(loggerContext, '[!!!DEPRECATION WARNING!!!]: dust.isDebug is deprecated.  Set dust.debugLevel instead to the level of logging you want ["debug","info","warn","error","none"]');
       dust.debugLevel = INFO;
     }
     type = type || INFO;
-    if(levels.indexOf(type) >= levels.indexOf(dust.debugLevel)) {
+    if(loggingLevels.indexOf(type) >= loggingLevels.indexOf(dust.debugLevel)) {
       if(!dust.logQueue) {
         dust.logQueue = [];
       }
@@ -51,7 +53,7 @@
    */
   dust.onError = function(error, chunk) {
     dust.log(error.message || error, ERROR);
-    if(levels.indexOf(dust.debugLevel) < levels.indexOf(SILENT)) {
+    if(!dust.silenceErrors) {
       throw error;
     } else {
       return chunk;

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -1844,20 +1844,21 @@ var coreTests = [
                    }
                  },
         error: "Error should be visible",
-        message: "test to make sure non dust errors are not swallowed."
+        message: "test to make sure errors are not swallowed."
       },
       {
         name: "Non dust errors should not be propogated when debug level is set to SILENT",
         source: "Error should NOT be visible{#errorHelper}{/errorHelper}",
         context: { "errorHelper" : function(chunk, context, bodies, params)
                    {
-                     dust.debugLevel = 'SILENT';
+                     dust.debugLevel = 'NONE';
+                     dust.silenceErrors = true;
                      throw new Error('Error should be visible');
                      return chunk.write('');
                    }
                  },
         expected: "Error should NOT be visible",
-        message: "test to make sure non dust errors are swallowed when the silenceAllErrors flag is set."
+        message: "test to make sure non dust errors are swallowed when the silenceErrors flag is set."
       }
     ]
   }


### PR DESCRIPTION
Fixes issue #381
