### PR TITLE
#204: add context to filter args

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -156,7 +156,7 @@
   };
 
   // apply the filter chain and return the output string
-  dust.filter = function(string, auto, filters) {
+  dust.filter = function(string, auto, filters, context) {
     if (filters) {
       for (var i=0, len=filters.length; i<len; i++) {
         var name = filters[i];
@@ -165,7 +165,7 @@
           dust.log('Using unescape filter on [' + string + ']', DEBUG);
         }
         else if (typeof dust.filters[name] === 'function') {
-          string = dust.filters[name](string);
+          string = dust.filters[name](string, context);
         }
         else {
           dust.onError(new Error('Invalid filter [' + name + ']'));
@@ -174,7 +174,7 @@
     }
     // by default always apply the h filter, unless asked to unescape with |s
     if (auto) {
-      string = dust.filters[auto](string);
+      string = dust.filters[auto](string, context);
     }
     return string;
   };
@@ -198,7 +198,18 @@
       } else {
         return JSON.parse(value);
       }
-    }
+    },
+		eb: function(value, context){
+			var phs = value.match(/\{([0-9a-zA-Z]+?)\}/g);
+			var pn, pval, rx;
+			for (var i = 0, len = phs.length; i<len; i++) {
+				pn = phs[i].substr(1).replace("}","");
+				pval = context.get(pn);
+				rx = new RegExp("{" + pn + "}", "g");
+				value = value.replace(rx,pval);
+			}
+			return value;
+		}
   };
 
   function Context(stack, global, blocks, templateName) {
@@ -551,7 +562,7 @@
       }
     }
     if (!dust.isEmpty(elem)) {
-      return this.write(dust.filter(elem, auto, filters));
+      return this.write(dust.filter(elem, auto, filters, context));
     } else {
       return this;
     }

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -113,6 +113,13 @@ var coreTests = [
         message: "should test escape_pragma"
       },
       {
+      	name: "filter extend brace",
+      	source: "{message|eb}",
+      	context: { message: "Hello, {name}", name: "World" },
+      	expected: "Hello, World",
+      	message: "should test extending braces"
+      },
+      {
          name:   "use . for creating a block and set params",
          source: "{#. test=\"you\"}{name} {test}{/.}",
          context: { name: "me"},
@@ -959,7 +966,7 @@ var coreTests = [
 /**
  * PARTIAL DEFINITIONS TESTS
  */
-  { 
+  {
     name: "partial definitions",
     tests: [
       {


### PR DESCRIPTION
I added this based on @rragan's code from #204. This will allow for double evaluation through a filter called ```eb```