### PR TITLE
Issue #413 point dustc to the correct version of server dust 

### DIFF
--- a/bin/dustc
+++ b/bin/dustc
@@ -3,7 +3,7 @@
 var path = require('path'),
     fs = require('fs'),
     sys = require('util'),
-    dust = require('../lib/dust'),
+    dust = require('../lib/server'),
     args = process.argv.slice(1),
     name = null;
 


### PR DESCRIPTION
dustc got lost in the shuffle with the 2.3 cleanup. Tested by running the dustc command locally.

Unit test requires some more cleanup. TBD
