### PR TITLE
Back compatible compiler

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -350,7 +350,7 @@
     },
 
     key: function(context, node) {
-      return 'ctx._get(false, ["' + node[1] + '"])';
+      return 'ctx.get(["' + node[1] + '"], false)';
     },
 
     path: function(context, node) {
@@ -365,7 +365,7 @@
           list.push('"' + keys[i] + '"');
         }
       }
-      return 'ctx._get(' + current + ',[' + list.join(',') + '])';
+      return 'ctx.get([' + list.join(',') + '] ,' + current + ')';
     },
 
     literal: function(context, node) {

--- a/test/server.js
+++ b/test/server.js
@@ -1,9 +1,11 @@
 /*global global, process, console */
 var uutest    = require('./uutest'),
-    dust      = require('../lib/server'),
     coreTests     = require('./jasmine-test/spec/coreTests'),
     coreSetup = require('./core').coreSetup;
 
+//make dust a global
+dust = require('../lib/server');
+//load additional helpers used in testing
 require('./jasmine-test/spec/testHelpers');
 
 function dumpError(err) {


### PR DESCRIPTION
In Dust 2.2.0 we've introduced backward incompatible change to the compiler (using `Context.prototype._get` instead of `Context.prototype.get` and `Context.prototype.getPath`). `_get` method was added to Dust 2.2.0 runtime. With that change, templates compiled in 2.2.0 and newer can not be rendered with Dust runtimes prior to 2.2.0. 

This pull request makes sure that older Dust runtimes (before 2.2.0) can render templates compiled with Dust 2.2.6 and beyond and 2.3.4 and beyond.

I am switching compiler from `_get` to `get`. This way older runtimes will use old implementation of `get` method. Newer runtimes will use new implementation of `get` method which calls `_get` under the hood.

Patching 2.2.x and 2.3.x versions
