### PR TITLE
Follow up on #420

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -365,7 +365,7 @@
           list.push('"' + keys[i] + '"');
         }
       }
-      return 'ctx.get([' + list.join(',') + '] ,' + current + ')';
+      return 'ctx.getPath(' + current + ', [' + list.join(',') + '])';
     },
 
     literal: function(context, node) {


### PR DESCRIPTION
After doing some testing discovered that one of the `get` calls in compiler should be `getPath`. Without that paths with dots in them will not work in old runtimes. Fixing that with this pull request.

Re-ran unit tests for both 2.2.x and 2.3.x. Runtime and compiler of same version work well together.

Also ran core unit tests from 1.2.5 compiled in 2.2.x and 2.3.x in 1.2.5 runtime. All of the unit tests rendered as expected with this change to use `getPath`.
