### PR TITLE
Output escaped JS strings when compiling

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -149,7 +149,7 @@
     };
 
     return '(function(){dust.register(' +
-        (name ? '"' + name + '"' : 'null') + ',' +
+        (name ? '"' + escapeToJsSafeString(name) + '"' : 'null') + ',' +
         compiler.compileNode(context, ast) +
         ');' +
         compileBlocks(context) +


### PR DESCRIPTION
The compiler wasn't escaping javascript string literals.