### PR TITLE
IE debugger fixes

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -8,17 +8,29 @@
       DEBUG = 'DEBUG',
       loggingLevels = [DEBUG, INFO, WARN, ERROR, NONE],
       EMPTY_FUNC = function() {},
-      logger = EMPTY_FUNC,
-      loggerContext = this;
+      logger = {},
+      loggerContext;
 
   dust.debugLevel = NONE;
   dust.silenceErrors = false;
 
-  // Try to find the console logger in global scope
-  if (root && root.console && root.console.log) {
-    logger = root.console.log;
+  // Try to find the console in global scope
+  if (root && root.console) {
     loggerContext = root.console;
   }
+
+  // robust logger for node.js, modern browsers, and IE <= 9.
+  logger.log = loggerContext ? function() {
+    var originalLog = loggerContext.log;
+      if (typeof originalLog === 'function') {
+        // Do this for normal browsers
+        originalLog.apply(loggerContext, arguments);
+      } else {
+        // Do this for IE <= 9
+        var message = Array.prototype.slice.apply(arguments).join(' ');
+        originalLog(message);
+      }
+  } : function() { /* no op */ };
 
   /**
    * If dust.isDebug is true, Log dust debug statements, info statements, warning statements, and errors.
@@ -29,17 +41,17 @@
    */
   dust.log = function(message, type) {
     if(dust.isDebug && dust.debugLevel === NONE) {
-      logger.call(loggerContext, '[!!!DEPRECATION WARNING!!!]: dust.isDebug is deprecated.  Set dust.debugLevel instead to the level of logging you want ["debug","info","warn","error","none"]');
+      logger.log('[!!!DEPRECATION WARNING!!!]: dust.isDebug is deprecated.  Set dust.debugLevel instead to the level of logging you want ["debug","info","warn","error","none"]');
       dust.debugLevel = INFO;
     }
 
     type = type || INFO;
-    if (loggingLevels.indexOf(type) >= loggingLevels.indexOf(dust.debugLevel)) {
+    if (dust.indexInArray(loggingLevels, type) >= dust.indexInArray(loggingLevels, dust.debugLevel)) {
       if(!dust.logQueue) {
         dust.logQueue = [];
       }
       dust.logQueue.push({message: message, type: type});
-      logger.call(loggerContext, '[DUST ' + type + ']: ' + message);
+      logger.log('[DUST ' + type + ']: ' + message);
     }
 
     if (!dust.silenceErrors && type === ERROR) {
@@ -59,7 +71,7 @@
    * @public
    */
   dust.onError = function(error, chunk) {
-    logger.call(loggerContext, '[!!!DEPRECATION WARNING!!!]: dust.onError will no longer return a chunk object.');
+    logger.log('[!!!DEPRECATION WARNING!!!]: dust.onError will no longer return a chunk object.');
     dust.log(error.message || error, ERROR);
     if(!dust.silenceErrors) {
       throw error;
@@ -156,6 +168,40 @@
       return Object.prototype.toString.call(arr) === '[object Array]';
     };
   }
+
+  // indexOf shim for arrays for IE <= 8
+  // source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf
+  dust.indexInArray = function(arr, item, fromIndex) {
+    fromIndex = +fromIndex || 0;
+    if (Array.prototype.indexOf) {
+      return arr.indexOf(item, fromIndex);
+    } else {
+    if ( arr === undefined || arr === null ) {
+      throw new TypeError( 'cannot call method "indexOf" of null' );
+    }
+
+    var length = arr.length; // Hack to convert object.length to a UInt32
+
+    if (Math.abs(fromIndex) === Infinity) {
+      fromIndex = 0;
+    }
+
+    if (fromIndex < 0) {
+      fromIndex += length;
+      if (fromIndex < 0) {
+        fromIndex = 0;
+      }
+    }
+
+    for (;fromIndex < length; fromIndex++) {
+      if (this[fromIndex] === item) {
+        return fromIndex;
+      }
+    }
+
+    return -1;
+    }
+  };
 
   dust.nextTick = (function() {
     return function(callback) {
@@ -838,4 +884,3 @@
   }
 
 })(this);
-


### PR DESCRIPTION
Fixes two issues:
1. IE8 and below throws an error when calling indexOf on an array, so make a dust shim for it ( #418 )
2. IE9 and below treats console.log as an object as an object instead of a function, so add a check for that, and if it's an object, call it directly

This is patching back to 2.1.x so please double check the commit history.
