### PR TITLE
IE debugger fixes

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -9,19 +9,20 @@
       loggingLevels = [DEBUG, INFO, WARN, ERROR, NONE],
       EMPTY_FUNC = function() {},
       logger = {},
+      originalLog,
       loggerContext;
 
   dust.debugLevel = NONE;
   dust.silenceErrors = false;
 
   // Try to find the console in global scope
-  if (root && root.console) {
+  if (root && root.console && root.console.log) {
     loggerContext = root.console;
+    originalLog = root.console.log;
   }
 
   // robust logger for node.js, modern browsers, and IE <= 9.
   logger.log = loggerContext ? function() {
-    var originalLog = loggerContext.log;
       // Do this for normal browsers
       if (typeof originalLog === 'function') {
         logger.log = function() {


### PR DESCRIPTION
Fixes two issues:
1. IE8 and below throws an error when calling indexOf on an array, so make a dust shim for it ( #418 )
2. IE9 and below treats console.log as an object as an object instead of a function, so add a check for that, and if it's an object, call it directly

This is patching back to 2.1.x so please double check the commit history.
