### PR TITLE
Remove dust.isDebug and remove dust.onErrors return value

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -39,18 +39,13 @@
   } : function() { /* no op */ };
 
   /**
-   * If dust.isDebug is true, Log dust debug statements, info statements, warning statements, and errors.
+   * Based on dust.debugLevel log dust debug statements, info statements, warning statements, and errors.
    * This default implementation will print to the console if it exists.
    * @param {String|Error} message the message to print/throw
    * @param {String} type the severity of the message(ERROR, WARN, INFO, or DEBUG)
    * @public
    */
   dust.log = function(message, type) {
-    if(dust.isDebug && dust.debugLevel === NONE) {
-      logger.log('[!!!DEPRECATION WARNING!!!]: dust.isDebug is deprecated.  Set dust.debugLevel instead to the level of logging you want ["debug","info","warn","error","none"]');
-      dust.debugLevel = INFO;
-    }
-
     type = type || INFO;
     if (dust.indexInArray(loggingLevels, type) >= dust.indexInArray(loggingLevels, dust.debugLevel)) {
       if(!dust.logQueue) {
@@ -70,19 +65,16 @@
   };
 
   /**
-   * If debugging is turned on(dust.isDebug=true) log the error message and throw it.
-   * Otherwise try to keep rendering.  This is useful to fail hard in dev mode, but keep rendering in production.
+   * If dust.debugLevel is set to ERROR or below, log the error message.  Throwing the error is gated by dust.silenceErrors.
+   * If dust.silenceErrors is false try to keep rendering.  This is useful to fail hard in dev mode, but keep rendering in production.
    * @param {Error} error the error message to throw
    * @param {Object} chunk the chunk the error was thrown from
    * @public
    */
   dust.onError = function(error, chunk) {
-    logger.log('[!!!DEPRECATION WARNING!!!]: dust.onError will no longer return a chunk object.');
     dust.log(error.message || error, ERROR);
     if(!dust.silenceErrors) {
       throw error;
-    } else {
-      return chunk;
     }
   };
 

--- a/test/core.js
+++ b/test/core.js
@@ -144,8 +144,7 @@ function testRender(unit, source, context, expected, options, baseContext, error
   var name = unit.id,
       messageInLog = '';
    try {
-     dust.isDebug = !!(error || logMessage);
-     dust.debugLevel = 'DEBUG';
+     dust.debugLevel = (error || logMessage) ? 'DEBUG' : 'NONE';
      dust.loadSource(dust.compile(source, name));
      if (baseContext){
         context = dust.makeBase(baseContext).push(context);

--- a/test/jasmine-test/spec/renderTestSpec.js
+++ b/test/jasmine-test/spec/renderTestSpec.js
@@ -14,8 +14,7 @@ function render(test) {
   return function() {
     var context;
     try {
-      dust.isDebug = !!(test.error || test.log);
-      dust.debugLevel = 'DEBUG';
+      dust.debugLevel = (test.error || test.log) ? 'DEBUG' : 'NONE';
       dust.loadSource(dust.compile(test.source, test.name, test.strip));
       context = test.context;
       if (test.base) {
@@ -56,8 +55,7 @@ function stream(test) {
       output = '';
       log = [];
       try {
-        dust.isDebug = !!(test.error || test.log);
-        dust.debugLevel = 'DEBUG';
+        dust.debugLevel = (test.error || test.log) ? 'DEBUG' : 'NONE';
         dust.loadSource(dust.compile(test.source, test.name));
         context = test.context;
         if (test.base){
@@ -144,8 +142,7 @@ function pipe(test) {
       messageInLog = false;
       messageInLogTwo = false;
       try {
-        dust.isDebug = !!(test.error || test.log);
-        dust.debugLevel = 'DEBUG';
+        dust.debugLevel = (test.error || test.log) ? 'DEBUG' : 'NONE';
         dust.loadSource(dust.compile(test.source, test.name));
         context = test.context;
         if (test.base){


### PR DESCRIPTION
This is step 1 of removing/deprecating a few debugging features.

step 2) dust v2.4.x
- Deprecate error throwing in dust.log, since it's overreaching its domain.
- Deprecate dust.onError to rename it to dust.throwError, since dust.onError implies it's a callback.

step 3) dust v2.5.x
- Remove error throwing in dust.log
- Rename dust.onError -> dust.throwError
