### PR TITLE
make console.log available for logging statements in node environment

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -889,4 +889,4 @@
     root.dust = dust;
   }
 
-})(this);
+})((function(){return this;})());


### PR DESCRIPTION
In a node environment, `this` is not the global object in the scope of a module.  So when it is passed as `root`, there is no console.log present on in, so log statements are never printed.  This pull request passes the correct global object in any context, fixing logging statements when running under node.
