### PR TITLE
[controversial] Make dust.render return the output when there is no callback defined

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -98,9 +98,19 @@
   };
 
   dust.render = function(name, context, callback) {
-    var chunk = new Stub(callback).head;
+    var chunk = new Stub(callback).head,
+        output;
     try {
-      dust.load(name, chunk, Context.wrap(context, name)).end();
+      if (callback) {
+        dust.load(name, chunk, Context.wrap(context, name)).end();
+      } else if (dust.cache[name]) {
+        dust.render(name, context, function(err, out) {
+          output = out;
+        });
+        return output;
+      } else {
+        throw '[DUST ERROR] template [' + name + '] not found in dust.render';
+      }
     } catch (err) {
       dust.log(err, ERROR);
     }

--- a/test/jasmine-test/spec/renderTestSpec.js
+++ b/test/jasmine-test/spec/renderTestSpec.js
@@ -3,6 +3,7 @@ describe ('Test the basic functionality of dust', function() {
     for (var i = 0; i < coreTests[index].tests.length; i++) {
       var test = coreTests[index].tests[i];
       it ('RENDER: ' + test.message, render(test));
+      it ('RENDERSYNC: ' + test.message, render(test));
       it ('STREAM: ' + test.message, stream(test));
       it ('PIPE: ' + test.message, pipe(test));
     }
@@ -37,6 +38,40 @@ function render(test) {
           expect(test.expected).toEqual(output);
         }
       });
+    }
+    catch (error) {
+      expect(test.error || {} ).toEqual(error.message);
+    }
+  };
+}
+
+function renderSync(test) {
+  var messageInLog = false;
+  return function() {
+    var context, output;
+    try {
+      dust.isDebug = !!(test.error || test.log);
+      dust.debugLevel = 'DEBUG';
+      dust.loadSource(dust.compile(test.source, test.name, test.strip));
+      context = test.context;
+      if (test.base) {
+        context = dust.makeBase(test.base).push(context);
+      }
+      output = dust.render(test.name, context);
+
+      var log = dust.logQueue;
+      if (test.log) {
+        for(var i=0; i<log.length; i++) {
+          if(log[i].message === test.log) {
+            messageInLog = true;
+            break;
+          }
+        }
+        dust.logQueue = [];
+        expect(messageInLog).toEqual(true);
+      } else {
+        expect(test.expected).toEqual(output);
+      }
     }
     catch (error) {
       expect(test.error || {} ).toEqual(error.message);


### PR DESCRIPTION
Allows dust to behave fully synchronously when the template is already loaded and compiled.