### PR TITLE
Don't instaevaluate generated body_ functions.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -11,7 +11,7 @@
   var compiler = {},
       isArray = dust.isArray;
 
-  
+
   compiler.compile = function(source, name) {
     // the name parameter is optional.
     // this can happen for templates that are rendered immediately (renderSource which calls compileFn) or
@@ -21,7 +21,7 @@
     if (!name && name !== null) {
       throw new Error('Template name parameter cannot be undefined when calling dust.compile');
     }
- 
+
     try {
       var ast = filterAST(parse(source));
       return compile(ast, name);
@@ -181,7 +181,7 @@
 
     for (i=0, len=bodies.length; i<len; i++) {
       out[i] = 'function body_' + i + '(chk,ctx){' +
-          blx + 'return chk' + bodies[i] + ';}';
+          blx + 'return chk' + bodies[i] + ';}body_' + i + '.__dustBody=!0;';
     }
     return out.join('');
   }
@@ -411,8 +411,7 @@
   dust.pragmas = compiler.pragmas;
   dust.compileNode = compiler.compileNode;
   dust.nodes = compiler.nodes;
-  
+
   return compiler;
 
 }));
-

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -295,7 +295,7 @@
   Context.prototype._get = function(cur, down) {
     var ctx = this.stack,
         i = 1,
-        value, first, len, ctxThis;
+        value, first, len, ctxThis, fn;
     first = down[0];
     len = down.length;
 
@@ -340,7 +340,7 @@
 
     // Return the ctx or a function wrapping the application of the context.
     if (typeof ctx === 'function') {
-      return function() {
+      fn = function() {
         try {
           return ctx.apply(ctxThis, arguments);
         } catch (err) {
@@ -348,6 +348,8 @@
           throw err;
         }
       };
+      fn.__dustBody = !!ctx.__dustBody;
+      return fn;
     } else {
       if (ctx === undefined) {
         dust.log('Cannot find the value for reference [{' + down.join('.') + '}] in template [' + this.getTemplateName() + ']');
@@ -610,7 +612,7 @@
 
   Chunk.prototype.section = function(elem, context, bodies, params) {
     // anonymous functions
-    if (typeof elem === 'function') {
+    if (typeof elem === 'function' && !elem.__dustBody) {
       try {
         elem = elem.apply(context.current(), [this, context, bodies, params]);
       } catch(e) {

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -1247,6 +1247,13 @@ var coreTests = [
         context:  { helper: function(chunk, context, bodies, params) { return chunk.write(params['data-foo']); } },
         expected: "dashes",
         message: "should test parameters with dashes"
+      },
+      {
+	name:     "inline params as dust function",
+	source:   "{#section a=\"{b}\"}{#a}Hello, {.}!{/a}{/section}",
+	context:  {"section": true, "b": "world"},
+	expected: "Hello, world!",
+	message: "Inline params that evaluate to a dust function should evaluate their body"
       }
     ]
   },
@@ -1322,13 +1329,13 @@ var coreTests = [
         context: {
                    foo: {
                      foobar: 'Foo Bar',
-                     bar: function () {
+                     bar: function biz() {
                        return this.foobar;
                      }
                    }
                  },
         expected: "Hello Foo Bar World!",
-        message: "should test scope of context function"
+        message: "should test that a non-chunk return value is used for truthiness"
       },
       {
         name: "test that function that do not return chunk and return falsy are treated as falsy",
@@ -1378,7 +1385,7 @@ var coreTests = [
                       }
                     },
           expected: "Hello Foo Bar World!",
-          message: "should test scope of context function"
+          message: "should test that function returning object is resolved"
         }
     ]
   },


### PR DESCRIPTION
Instead, place them into the context and attempt to render their containing block.

Closes #512.
