### PR TITLE
Remove the warning log when you attach a new Stream event

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -497,7 +497,6 @@
       this.events = {};
     }
     if (!this.events[type]) {
-      dust.log('Event type [' + type + '] does not exist. Using just the specified callback.', WARN);
       if(callback) {
         this.events[type] = callback;
       } else {


### PR DESCRIPTION
If there are no listeners on an event yet (like 'data'), you get a WARN the first time you add one. That's silly.
