### PR TITLE
Fix the use of a multi-level object key (e.g. foo.bar) as the key for an index lookup inside non-self-closing tags.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -107,7 +107,7 @@
         peg$c42 = { type: "literal", value: "~", description: "\"~\"" },
         peg$c43 = function(k) { return ["special", k].concat([['line', line()], ['col', column()]]) },
         peg$c44 = { type: "other", description: "identifier" },
-        peg$c45 = function(p) { var arr = ["path"].concat(p); arr.text = p[1].join('.'); return arr; },
+        peg$c45 = function(p) { var arr = ["path"].concat(p); arr.text = p[1].join('.').replace(/,line,\d+,col,\d+/g,''); return arr; },
         peg$c46 = function(k) { var arr = ["key", k]; arr.text = k; return arr; },
         peg$c47 = { type: "other", description: "number" },
         peg$c48 = function(n) { return ['literal', n]; },

--- a/src/dust.pegjs
+++ b/src/dust.pegjs
@@ -111,7 +111,7 @@ special "special"
    identifier is defined as matching a path or key
 ---------------------------------------------------------------------------------------------------------------------------------------*/
 identifier "identifier"
-  = p:path     { var arr = ["path"].concat(p); arr.text = p[1].join('.'); return arr; }
+  = p:path     { var arr = ["path"].concat(p); arr.text = p[1].join('.').replace(/,line,\d+,col,\d+/g,''); return arr; }
   / k:key      { var arr = ["key", k]; arr.text = k; return arr; }
 
 number "number"

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -676,6 +676,18 @@ var coreTests = [
         context: { "test": [[ 1,2,3 ]]},
         expected: "1i:0l:3,2i:1l:3,3i:2l:3,",
         message: "should test double nested array and . reference: issue #340"
+      },
+      {
+	name: "using a nested key as a reference for array index access",
+	source: "{#loop.array[key.foo].sub}{.}{/loop.array[key.foo].sub}",
+	context: {
+		  "loop": {
+		   "array": {"thing": {sub: 1, sap: 2}, "thing2": "bar"}
+		  },
+		  "key": { "foo": "thing" }
+		 },
+	expected: "1",
+	message: "should test using a multilevel reference as a key in array access"
       }
     ]
   },


### PR DESCRIPTION
Closes #521.

This internal `.text` property is used to compare start and close tags to ensure they're balanced. When the tag contains a path lookup, the lookup is itself a compiled node. When a node is compiled, line-number information is attached, which causes the tag to become inbalanced.

The patch simply strips line-number information from this internal marker.
