### PR TITLE
Don't stringify dust.log messages

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -71,7 +71,7 @@
         dust.logQueue = [];
       }
       dust.logQueue.push({message: message, type: type});
-      logger.log('[DUST ' + type + ']: ' + message);
+      logger.log('[DUST:' + type + ']', message);
     }
   };
 


### PR DESCRIPTION
I tried to dust.log({ some: "object"}) and got:

> [DUST INFO] [object Object]

So this fixes that.
