### PR TITLE
Fix hanging comma error in IE7

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -15,7 +15,7 @@
   dust.debugLevel = NONE;
 
   dust.config = {
-    whitespace: false,
+    whitespace: false
   };
 
   // Directive aliases to minify code


### PR DESCRIPTION
dustjs works just fine in IE7; however, this repo has a hanging comma in the default config that causes an error in IE7. This pull request simply removes this hanging comma so that the well-maintained LinkedIn fork of dustjs can be used w/ IE7.
