### PR TITLE
Added loadFn function to return a callable function that runs a template...

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -112,6 +112,22 @@
     return dust.compileFn(source)(context, callback);
   };
 
+  dust.loadFn = function(name) {
+    var tmpl = dust.cache[name];
+    if(typeof tmpl !== 'function') {
+      dust.log(new Error('Template [' + name + '] cannot be resolved to a Dust function'), ERROR);
+    }
+    else {
+      return function(context, callback) {
+        var master = callback ? new Stub(callback) : new Stream();
+        dust.nextTick(function() {
+          tmpl(master.head, Context.wrap(context, name)).end();
+        });
+        return master;
+      };
+    }
+  };
+
   dust.compileFn = function(source, name) {
     // name is optional. When name is not provided the template can only be rendered using the callable returned by this function.
     // If a name is provided the compiled template can also be rendered by name.


### PR DESCRIPTION
CompileFn will not work without the compiler, and often I find it more convenient to save the template function instead of having to call dust.render with the function name.

```
app.views.One = Backbone.Views.extend({
    template: dust.loadFn('partials/one'),
    render: function() {
        var that = this;
        this.template(context, function(err, out) {
            that.el.innerHTML = out;
        };
    }
});
```

