### PR TITLE
Stringify things before calling escapeHtml on them in case their stringified representation contains HTML

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -851,7 +851,10 @@
       SQUOT  = /\'/g;
 
   dust.escapeHtml = function(s) {
-    if (typeof s === 'string') {
+    if (typeof s === "string" || (s && typeof s.toString === "function")) {
+      if (typeof s !== "string") {
+        s = s.toString();
+      }
       if (!HCHARS.test(s)) {
         return s;
       }

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -688,6 +688,13 @@ var coreTests = [
 		 },
 	expected: "1",
 	message: "should test using a multilevel reference as a key in array access"
+      },
+      {
+	name: "Outputting an array calls toString and HTML-encodes",
+	source: "{array}",
+	context: { "array": ["You & I", " & Moe"] },
+	expected: "You &amp; I, &amp; Moe",
+	message: "should HTML-encode stringified arrays referenced directly"
       }
     ]
   },


### PR DESCRIPTION
This prevents a potential XSS attack.

Closes #449