### PR TITLE
Escape template names

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -161,7 +161,7 @@
     };
 
     return '(function(){dust.register(' +
-        (name ? '"' + name + '"' : 'null') + ',' +
+        (name ? '"' + dust.escapeJs(name) + '"' : 'null') + ',' +
         compiler.compileNode(context, ast) +
         ');' +
         compileBlocks(context) +

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -40,6 +40,13 @@ var coreTests = [
         message: "should test basic text rendering"
       },
       {
+        name:     "confusing \" \n \' \u0000 \u2028 \u2029 template name\\",
+        source:   "Hello World!",
+        context:  {},
+        expected: "Hello World!",
+        message:  "javascript-special characters in template names shouldn't break things"
+      },
+      {
         name:     "global_template",
         source:   '{#helper foo="bar" boo="boo"} {/helper}',
         context:  { "helper": function(chunk, context, bodies, params)


### PR DESCRIPTION
Since the compiler was not interpreting template names when emitting
javascript code with those as literals, and instead merely concatenating
string delimiters onto the end, template names ending in a backslash
or containing a newline or double quotes would cause a parser failure
when loading the compiled template.

This additionally escapes the null character, as some browsers will omit
it during parsing, making the template name not make a round-trip from
what was specified to what is cached.