### PR TITLE
Add Context#resolve

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -425,6 +425,19 @@
     return this;
   };
 
+  Context.prototype.resolve = function(body) {
+    var chunk;
+
+    if(typeof body !== 'function') {
+      return body;
+    }
+    chunk = new Chunk().render(body, this);
+    if(!body.__dustBody) {
+      return chunk;
+    }
+    return chunk.data.join(''); // ie7 perf
+  };
+
   Context.prototype.getTemplateName = function() {
     return this.templateName;
   };

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -49,9 +49,8 @@ var coreTests = [
       {
         name:     "global_template",
         source:   '{#helper foo="bar" boo="boo"} {/helper}',
-        context:  { "helper": function(chunk, context, bodies, params)
-                     {
-                      currentTemplateName = context.getTemplateName();
+        context:  { "helper": function(chunk, context, bodies, params) {
+                      var currentTemplateName = context.getTemplateName();
                       return chunk.write(currentTemplateName);
                      }
                   },
@@ -247,7 +246,31 @@ var coreTests = [
         expected: "Hello",
         message: "should test comments"
       },
-      {
+	  {
+		name: "context.resolve",
+		source: "{#foo bar=\"{baz} is baz \" literal=\"literal \" func=func chunkFunc=\"{chunkFunc}\" ref=ref}Fail{/foo}",
+		context: {
+		  foo: function(chunk, context, bodies, params) {
+			chunk.write(context.resolve(params.bar));
+			chunk.write(context.resolve(params.literal));
+			chunk.write(context.resolve(params.func));
+			chunk.write(context.resolve(params.chunkFunc));
+			chunk.write(context.resolve(params.ref));
+			return chunk;
+		  },
+		  baz: "baz",
+		  ref: "ref",
+		  func: function() {
+			return "func ";
+		  },
+		  chunkFunc: function(chunk) {
+			return chunk.write('chunk ');
+		  }
+		},
+		expected: "baz is baz literal func chunk ref",
+		message: "context.resolve() taps parameters from the context"
+	  },
+	  {
         name:     "context",
         source:   "{#list:projects}{name}{:else}No Projects!{/list}",
         context:  {


### PR DESCRIPTION
This function behaves similarly to dust.helpers.tap but is part of core and requires no passing of chunk and context parameters.

Closes #554