### PR TITLE
Add `context.clone` and `context.pop`

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -218,6 +218,25 @@
     return (!value);
   };
 
+  dust.isEmptyObject = function(obj) {
+    var key;
+    if (obj === null) {
+      return false;
+    }
+    if (obj === undefined) {
+      return false;
+    }
+    if (obj.length > 0) {
+      return false;
+    }
+    for (key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        return false;
+      }
+    }
+    return true;
+  };
+
   // apply the filter chain and return the output string
   dust.filter = function(string, auto, filters) {
     if (filters) {
@@ -308,7 +327,7 @@
    * @return {string | object}
    */
   Context.prototype._get = function(cur, down) {
-    var ctx = this.stack,
+    var ctx = this.stack || {},
         i = 1,
         value, first, len, ctxThis, fn;
     first = down[0];
@@ -381,12 +400,24 @@
     return new Context(new Stack(head, this.stack, idx, len), this.global, this.blocks, this.getTemplateName());
   };
 
+  Context.prototype.pop = function() {
+    var head = this.current();
+    this.stack = this.stack && this.stack.tail;
+    return head;
+  };
+
   Context.prototype.rebase = function(head) {
     return new Context(new Stack(head), this.global, this.blocks, this.getTemplateName());
   };
 
+  Context.prototype.clone = function() {
+    var context = this.rebase();
+    context.stack = this.stack;
+    return context;
+  };
+
   Context.prototype.current = function() {
-    return this.stack.head;
+    return this.stack && this.stack.head;
   };
 
   Context.prototype.getBlock = function(key, chk, ctx) {
@@ -743,37 +774,26 @@
   };
 
   Chunk.prototype.partial = function(elem, context, params) {
-    var partialContext;
-    //put the params context second to match what section does. {.} matches the current context without parameters
-    // start with an empty context
-    partialContext = dust.makeBase(context.global);
-    partialContext.blocks = context.blocks;
-    if (context.stack && context.stack.tail){
-      // grab the stack(tail) off of the previous context if we have it
-      partialContext.stack = context.stack.tail;
-    }
-    if (params){
-      //put params on
-      partialContext = partialContext.push(params);
+    var head;
+
+    if (!dust.isEmptyObject(params)) {
+      context = context.clone();
+      head = context.pop();
+      context = context.push(params)
+                       .push(head);
     }
 
-    if(typeof elem === 'string') {
-      partialContext.templateName = elem;
-    }
-
-    //reattach the head
-    partialContext = partialContext.push(context.stack.head);
-
-    var partialChunk;
-    if (typeof elem === 'function') {
-      partialChunk = this.capture(elem, partialContext, function(name, chunk) {
-        partialContext.templateName = partialContext.templateName || name;
-        dust.load(name, chunk, partialContext).end();
+    if (elem.__dustBody) {
+      // The eventual result of evaluating `elem` is a partial name
+      // Load the partial after getting its name and end the async chunk
+      return this.capture(elem, context, function(name, chunk) {
+        context.templateName = name;
+        dust.load(name, chunk, context).end();
       });
     } else {
-      partialChunk = dust.load(elem, this, partialContext);
+      context.templateName = elem;
+      return dust.load(elem, this, context);
     }
-    return partialChunk;
   };
 
   Chunk.prototype.helper = function(name, context, bodies, params) {

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -1056,11 +1056,18 @@ var coreTests = [
     tests : [
       {
         name:     "partials",
-        source:   '{>partial/} {>"hello_world"/} {>"{ref}"/}',
+        source:   '{>partial foo=0 /} {>"hello_world" foo=1 /} {>"{ref}" foo=2 /}',
         context:  { name: "Jim", count: 42, ref: "hello_world" },
         expected: "Hello Jim! You have 42 new messages. Hello World! Hello World!",
         message:  "should test partials"
       },
+	  {
+		name:	  "partial with async ref as name",
+		source:   '{>"{ref}" /}',
+		context:  { ref: function(chunk, context) { return chunk.map(function(chunk) { setTimeout(function() { chunk.end('hello_world'); }) }); }},
+		expected: "Hello World!",
+		message:  "should test partial with an asynchronously-resolved template name"
+	  },
       {
         name:     "partial with context",
         source:   "{>partial:.profile/}",

--- a/test/jasmine-test/spec/renderTestSpec.js
+++ b/test/jasmine-test/spec/renderTestSpec.js
@@ -28,7 +28,9 @@ function render(test) {
           err = err.message || err;
           expect(err).toContain(test.error);
         } else {
-          expect(err).toBeNull();
+          if(err) {
+            expect(err.message).toBeNull();
+          }
         }
         if (test.log) {
           for(var i=0; i<log.length; i++) {


### PR DESCRIPTION
This is a starting point for discussion, probably not final.

I added the `clone` method because `Chunk#partial` can resolve partials asynchronously, so you run into closure issues if you don't clone the working context. But it's useful anyways.

Closes #558