### PR TITLE
Removed Download & Setup link from the guides list

### DIFF
--- a/_includes/nav.md
+++ b/_includes/nav.md
@@ -9,7 +9,6 @@
     <li>
       Guides
       <ul>
-      <li><a href="/guides/setup">Download &amp; Setup</a></li>
       <li><a href="/guides/getting-started">Getting Started</a></li>
       <li><a href="/guides/context-helpers">Context Helpers</a></li>
       <li><a href="/guides/dust-helpers">Dust Helpers</a></li>


### PR DESCRIPTION
Removing extra link to downloading and setup guide from the navigation.