### PR TITLE
Clean up / refactor logging

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -172,8 +172,18 @@ module.exports = function(grunt) {
         }
       }
     },
-    jasmine_node: {
-      dustc: ['test/jasmine-test/spec/cli/']
+    jasmine_nodejs: {
+      dustc: {
+        specs: ['test/jasmine-test/spec/cli/*'],
+        options: {
+          reporters: {
+            console: {
+              colors: false,
+              verbose: false
+            }
+          }
+        }
+      }
     },
     watch: {
       lib: {
@@ -247,7 +257,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-gh-pages');
   grunt.loadNpmTasks('grunt-bump');
   grunt.loadNpmTasks('grunt-shell');
-  grunt.loadNpmTasks('grunt-jasmine-node');
+  grunt.loadNpmTasks('grunt-jasmine-nodejs');
 
   //--------------------------------------------------
   //------------Grunt task aliases -------------------
@@ -259,8 +269,8 @@ module.exports = function(grunt) {
   grunt.registerTask('testNode',       ['shell:oldTests']);
   grunt.registerTask('testRhino',      ['build', 'shell:testRhino']);
   grunt.registerTask('testPhantom',    ['build', 'jasmine:testProd']);
-  grunt.registerTask('testCli',        ['build', 'jasmine_node:dustc']);
-  grunt.registerTask('test',           ['build', 'jasmine:testProd', 'jasmine_node:dustc', 'shell:oldTests', 'shell:testRhino', 'jasmine:coverage']);
+  grunt.registerTask('testCli',        ['build', 'jasmine_nodejs:dustc']);
+  grunt.registerTask('test',           ['build', 'jasmine:testProd', 'jasmine_nodejs:dustc', 'shell:oldTests', 'shell:testRhino', 'jasmine:coverage']);
 
   //task for debugging in browser
   grunt.registerTask('dev',            ['build', 'jasmine:testDev:build', 'connect:testServer','log:testClient', 'watch:lib']);

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -733,6 +733,7 @@
       if (body) {
         return body(this, context);
       }
+      dust.log('No block for exists check in template `' + context.getTemplateName() + '`', DEBUG);
     } else if (skip) {
       return skip(this, context);
     }
@@ -747,6 +748,7 @@
       if (body) {
         return body(this, context);
       }
+      dust.log('No block for not-exists check in template `' + context.getTemplateName() + '`', DEBUG);
     } else if (skip) {
       return skip(this, context);
     }
@@ -791,9 +793,9 @@
     if(dust.helpers[name]) {
       try {
         return dust.helpers[name](chunk, context, bodies, params);
-      } catch(e) {
-        dust.log('Error in helper `' + name + '`: ' + e.message, ERROR);
-        return chunk.setError(e);
+      } catch(err) {
+        dust.log('Error in helper `' + name + '`: ' + err.message, ERROR);
+        return chunk.setError(err);
       }
     } else {
       dust.log('Helper `' + name + '` does not exist', WARN);

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -1,4 +1,3 @@
-/*jshint evil:true*/
 (function(root) {
   var dust = {
         "version": "2.6.1"
@@ -8,7 +7,13 @@
       WARN = 'WARN',
       INFO = 'INFO',
       DEBUG = 'DEBUG',
-      loggingLevels = [DEBUG, INFO, WARN, ERROR, NONE],
+      loggingLevels = {
+        DEBUG: 0,
+        INFO: 1,
+        WARN: 2,
+        ERROR: 3,
+        NONE: 4
+      },
       EMPTY_FUNC = function() {},
       logger = {},
       originalLog,
@@ -57,11 +62,10 @@
         };
       }
       logger.log.apply(this, arguments);
-  } : function() { /* no op */ };
+  } : EMPTY_FUNC;
 
   /**
-   * Log dust debug statements, info statements, warning statements, and errors.
-   * Filters out the messages based on the dust.debuglevel.
+   * Filters messages based on `dust.debugLevel`.
    * This default implementation will print to the console if it exists.
    * @param {String|Error} message the message to print/throw
    * @param {String} type the severity of the message(ERROR, WARN, INFO, or DEBUG)
@@ -69,11 +73,7 @@
    */
   dust.log = function(message, type) {
     type = type || INFO;
-    if (dust.debugLevel !== NONE && dust.indexInArray(loggingLevels, type) >= dust.indexInArray(loggingLevels, dust.debugLevel)) {
-      if(!dust.logQueue) {
-        dust.logQueue = [];
-      }
-      dust.logQueue.push({message: message, type: type});
+    if (loggingLevels[type] >= loggingLevels[dust.debugLevel]) {
       logger.log('[DUST:' + type + ']', message);
     }
   };
@@ -115,9 +115,14 @@
     return dust.compileFn(source)(context, callback);
   };
 
+  /**
+   * Compile a template to an invokable function.
+   * If `name` is provided, also registers the template under `name`.
+   * @param source {String} template source
+   * @param [name] {String} template name
+   * @return {Function} has the signature `fn(context, cb)`
+   */
   dust.compileFn = function(source, name) {
-    // name is optional. When name is not provided the template can only be rendered using the callable returned by this function.
-    // If a name is provided the compiled template can also be rendered by name.
     name = name || null;
     var tmpl = dust.loadSource(dust.compile(source, name));
     return function(context, callback) {
@@ -125,9 +130,8 @@
       dust.nextTick(function() {
         if(typeof tmpl === 'function') {
           tmpl(master.head, Context.wrap(context, name)).end();
-        }
-        else {
-          dust.log(new Error('Template [' + name + '] cannot be resolved to a Dust function'), ERROR);
+        } else {
+          dust.log(new Error('Template `' + name + '` could not be loaded'), ERROR);
         }
       });
       return master;
@@ -157,6 +161,7 @@
   };
 
   dust.loadSource = function(source, path) {
+    /*jshint evil:true*/
     return eval(source);
   };
 
@@ -168,54 +173,24 @@
     };
   }
 
-  // indexOf shim for arrays for IE <= 8
-  // source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf
-  dust.indexInArray = function(arr, item, fromIndex) {
-    fromIndex = +fromIndex || 0;
-    if (Array.prototype.indexOf) {
-      return arr.indexOf(item, fromIndex);
-    } else {
-    if ( arr === undefined || arr === null ) {
-      throw new TypeError( 'cannot call method "indexOf" of null' );
-    }
-
-    var length = arr.length; // Hack to convert object.length to a UInt32
-
-    if (Math.abs(fromIndex) === Infinity) {
-      fromIndex = 0;
-    }
-
-    if (fromIndex < 0) {
-      fromIndex += length;
-      if (fromIndex < 0) {
-        fromIndex = 0;
-      }
-    }
-
-    for (;fromIndex < length; fromIndex++) {
-      if (arr[fromIndex] === item) {
-        return fromIndex;
-      }
-    }
-
-    return -1;
-    }
-  };
-
   dust.nextTick = (function() {
     return function(callback) {
       setTimeout(callback,0);
     };
   } )();
 
+  /**
+   * Dust has its own rules for what is "empty"-- which is not the same as falsy.
+   * Empty arrays, null, and undefined are empty
+   */
   dust.isEmpty = function(value) {
-    if (dust.isArray(value) && !value.length) {
-      return true;
-    }
     if (value === 0) {
       return false;
     }
-    return (!value);
+    if (dust.isArray(value) && !value.length) {
+      return true;
+    }
+    return !value;
   };
 
   dust.isEmptyObject = function(obj) {
@@ -250,9 +225,10 @@
 
   // apply the filter chain and return the output string
   dust.filter = function(string, auto, filters) {
+    var i, len, name;
     if (filters) {
-      for (var i=0, len=filters.length; i<len; i++) {
-        var name = filters[i];
+      for (i = 0, len = filters.length; i < len; i++) {
+        name = filters[i];
         if (name === 's') {
           auto = null;
         }
@@ -260,7 +236,7 @@
           string = dust.filters[name](string);
         }
         else {
-          dust.log('Invalid filter [' + name + ']', WARN);
+          dust.log('Invalid filter `' + name + '`', WARN);
         }
       }
     }
@@ -278,7 +254,7 @@
     uc: encodeURIComponent,
     js: function(value) { return dust.escapeJSON(value); },
     jp: function(value) {
-      if (!JSON) {dust.log('JSON is undefined.  JSON parse has not been used on [' + value + ']', WARN);
+      if (!JSON) {dust.log('JSON is undefined; could not parse `' + value + '`', WARN);
         return value;
       } else {
         return JSON.parse(value);
@@ -371,7 +347,7 @@
         if(ctx.head) {
           ctx = ctx.head[first];
         } else {
-          //context's head is empty, value we are searching for is not defined
+          // context's head is empty, value we are searching for is not defined
           ctx = undefined;
         }
       }
@@ -383,7 +359,6 @@
       }
     }
 
-    // Return the ctx or a function wrapping the application of the context.
     if (typeof ctx === 'function') {
       fn = function() {
         try {
@@ -397,7 +372,7 @@
       return fn;
     } else {
       if (ctx === undefined) {
-        dust.log('Cannot find the value for reference [{' + down.join('.') + '}] in template [' + this.getTemplateName() + ']');
+        dust.log('Cannot find reference `{' + down.join('.') + '}` in template `' + this.getTemplateName() + '`', INFO);
       }
       return ctx;
     }
@@ -432,24 +407,29 @@
   };
 
   Context.prototype.getBlock = function(key, chk, ctx) {
+    var blocks, len, fn;
+
     if (typeof key === 'function') {
-      var tempChk = new Chunk();
-      key = key(tempChk, this).data.join('');
+      key = key(new Chunk(), this).data.join('');
     }
 
-    var blocks = this.blocks;
+    blocks = this.blocks;
 
     if (!blocks) {
-      dust.log('No blocks for context[{' + key + '}] in template [' + this.getTemplateName() + ']', DEBUG);
-      return;
+      dust.log('No blocks for context `' + key + '` in template `' + this.getTemplateName() + '`', DEBUG);
+      return false;
     }
-    var len = blocks.length, fn;
+
+    len = blocks.length;
     while (len--) {
       fn = blocks[len][key];
       if (fn) {
         return fn;
       }
     }
+
+    dust.log('Malformed template `' + this.getTemplateName() + '` was missing one or more blocks.');
+    return false;
   };
 
   Context.prototype.shiftBlocks = function(locals) {
@@ -506,7 +486,7 @@
         this.out += chunk.data.join(''); //ie7 perf
       } else if (chunk.error) {
         this.callback(chunk.error);
-        dust.log('Chunk error [' + chunk.error + '] thrown. Ceasing to render this template.', WARN);
+        dust.log('Rendering failed with error `' + chunk.error + '`', ERROR);
         this.flush = EMPTY_FUNC;
         return;
       } else {
@@ -530,7 +510,7 @@
         this.emit('data', chunk.data.join('')); //ie7 perf
       } else if (chunk.error) {
         this.emit('error', chunk.error);
-        dust.log('Chunk error [' + chunk.error + '] thrown. Ceasing to render this template.', WARN);
+        dust.log('Streaming failed with error `' + chunk.error + '`', ERROR);
         this.flush = EMPTY_FUNC;
         return;
       } else {
@@ -543,62 +523,52 @@
   };
 
   Stream.prototype.emit = function(type, data) {
-    if (!this.events) {
-      dust.log('No events to emit', INFO);
-      return false;
+    var events = this.events || {},
+        handlers = events[type] || [],
+        i, l;
+
+    if (!handlers.length) {
+      dust.log('Stream broadcasting, but no listeners for `' + type + '`', DEBUG);
+      return;
     }
-    var handler = this.events[type];
-    if (!handler) {
-      dust.log('Event type [' + type + '] does not exist', WARN);
-      return false;
-    }
-    if (typeof handler === 'function') {
-      handler(data);
-    } else if (dust.isArray(handler)) {
-      var listeners = handler.slice(0);
-      for (var i = 0, l = listeners.length; i < l; i++) {
-        listeners[i](data);
-      }
-    } else {
-      dust.log('Event Handler [' + handler + '] is not of a type that is handled by emit', WARN);
+
+    handlers = handlers.slice(0);
+    for (i = 0, l = handlers.length; i < l; i++) {
+      handlers[i](data);
     }
   };
 
   Stream.prototype.on = function(type, callback) {
-    if (!this.events) {
-      this.events = {};
-    }
-    if (!this.events[type]) {
-      if(callback) {
-        this.events[type] = callback;
-      } else {
-        dust.log('Callback for type [' + type + '] does not exist. Listener not registered.', WARN);
-      }
-    } else if(typeof this.events[type] === 'function') {
-      this.events[type] = [this.events[type], callback];
+    var events = this.events = this.events || {},
+        handlers = events[type] = events[type] || [];
+
+    if(typeof callback !== 'function') {
+      dust.log('No callback function provided for `' + type + '` event listener', WARN);
     } else {
-      this.events[type].push(callback);
+      handlers.push(callback);
     }
     return this;
   };
 
   Stream.prototype.pipe = function(stream) {
-    this.on('data', function(data) {
+    return this
+    .on('data', function(data) {
       try {
         stream.write(data, 'utf8');
       } catch (err) {
         dust.log(err, ERROR);
       }
-    }).on('end', function() {
+    })
+    .on('end', function() {
       try {
-        return stream.end();
+        stream.end();
       } catch (err) {
         dust.log(err, ERROR);
       }
-    }).on('error', function(err) {
+    })
+    .on('error', function(err) {
       stream.error(err);
     });
-    return this;
   };
 
   function Chunk(root, next, taps) {
@@ -636,9 +606,9 @@
     this.flushable = true;
     try {
       callback(branch);
-    } catch(e) {
-      dust.log(e, ERROR);
-      branch.setError(e);
+    } catch(err) {
+      dust.log(err, ERROR);
+      branch.setError(err);
     }
     return cursor;
   };
@@ -665,8 +635,6 @@
 
   Chunk.prototype.reference = function(elem, context, auto, filters) {
     if (typeof elem === 'function') {
-      // Changed the function calling to use apply with the current context to make sure
-      // that `this` is what we expect it to be inside the function
       elem = elem.apply(context.current(), [this, context, null, {auto: auto, filters: filters}]);
       if (elem instanceof Chunk) {
         return elem;
@@ -682,24 +650,25 @@
   };
 
   Chunk.prototype.section = function(elem, context, bodies, params) {
-    // anonymous functions
+    var body = bodies.block,
+        skip = bodies['else'],
+        chunk = this,
+        i, len;
+
     if (typeof elem === 'function' && !elem.__dustBody) {
       try {
         elem = elem.apply(context.current(), [this, context, bodies, params]);
-      } catch(e) {
-        dust.log(e, ERROR);
-        return this.setError(e);
+      } catch(err) {
+        dust.log(err, ERROR);
+        return this.setError(err);
       }
-      // functions that return chunks are assumed to have handled the body and/or have modified the chunk
-      // use that return value as the current chunk and go to the next method in the chain
+      // Functions that return chunks are assumed to have handled the chunk manually.
+      // Make that chunk the current one and go to the next method in the chain.
       if (elem instanceof Chunk) {
         return elem;
       }
     }
-    var body = bodies.block,
-        skip = bodies['else'];
 
-    // a.k.a Inline parameters in the Dust documentations
     if (params) {
       context = context.push(params);
     }
@@ -709,17 +678,15 @@
     When elem resolves to a value or object instead of an array, Dust sets the current context to the value
     and renders the block one time.
     */
-    //non empty array is truthy, empty array is falsy
     if (dust.isArray(elem)) {
       if (body) {
-        var len = elem.length, chunk = this;
+        len = elem.length;
         if (len > 0) {
-          // any custom helper can blow up the stack
-          // and store a flattened context, guard defensively
+          // any custom helper can blow up the stack and store a flattened context, guard defensively
           if(context.stack.head) {
             context.stack.head['$len'] = len;
           }
-          for (var i=0; i<len; i++) {
+          for (i = 0; i < len; i++) {
             if(context.stack.head) {
               context.stack.head['$idx'] = i;
             }
@@ -754,7 +721,7 @@
     } else if (skip) {
       return skip(this, context);
     }
-    dust.log('Not rendering section (#) block in template [' + context.getTemplateName() + '], because above key was not found', DEBUG);
+    dust.log('Section without corresponding key in template `' + context.getTemplateName() + '`', DEBUG);
     return this;
   };
 
@@ -769,7 +736,6 @@
     } else if (skip) {
       return skip(this, context);
     }
-    dust.log('Not rendering exists (?) block in template [' + context.getTemplateName() + '], because above key was not found', DEBUG);
     return this;
   };
 
@@ -784,16 +750,11 @@
     } else if (skip) {
       return skip(this, context);
     }
-    dust.log('Not rendering not exists (^) block check in template [' + context.getTemplateName() + '], because above key was found', DEBUG);
     return this;
   };
 
   Chunk.prototype.block = function(elem, context, bodies) {
-    var body = bodies.block;
-
-    if (elem) {
-      body = elem;
-    }
+    var body = elem || bodies.block;
 
     if (body) {
       return body(this, context);
@@ -831,11 +792,11 @@
       try {
         return dust.helpers[name](chunk, context, bodies, params);
       } catch(e) {
-        dust.log('Error in ' + name + ' helper: ' + e, ERROR);
+        dust.log('Error in helper `' + name + '`: ' + e.message, ERROR);
         return chunk.setError(e);
       }
     } else {
-      dust.log('Invalid helper [' + name + ']', WARN);
+      dust.log('Helper `' + name + '` does not exist', WARN);
       return chunk;
     }
   };
@@ -963,7 +924,7 @@
 
   dust.escapeJSON = function(o) {
     if (!JSON) {
-      dust.log('JSON is undefined.  JSON stringify has not been used on [' + o + ']', WARN);
+      dust.log('JSON is undefined; could not escape `' + o + '`', WARN);
       return o;
     } else {
       return JSON.stringify(o)

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "grunt-contrib-uglify": "~0.2.7",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-gh-pages": "~0.9.0",
-    "grunt-jasmine-node": "~0.2.1",
+    "grunt-jasmine-nodejs": "~1.0.2",
     "grunt-shell": "~0.6.1",
     "grunt-template-jasmine-istanbul": "~0.2.5",
     "pegjs": "0.8.0"

--- a/test/core.js
+++ b/test/core.js
@@ -119,25 +119,6 @@ exports.coreSetup = function(suite, auto) {
     });
   });
 
-  suite.test("indexInArray", function() {
-    var unit = this,
-        arr = ["hello", "world"],
-        nativeIndexOf = Array.prototype.indexOf,
-        indexOf;
-    indexOf = dust.indexInArray(arr, "world");
-    unit.equals(indexOf, 1);
-    indexOf = dust.indexInArray(arr, "foo");
-    unit.equals(indexOf, -1);
-    Array.prototype.indexOf = undefined;
-    // test indexOf when the array indexOf function is undefined (IE lte 8)
-    indexOf = dust.indexInArray(arr, "world");
-    unit.equals(indexOf, 1);
-    indexOf = dust.indexInArray(arr, "foo");
-    unit.equals(indexOf, -1);
-    Array.prototype.indexOf = nativeIndexOf;
-    unit.notEquals(Array.prototype.indexOf, undefined);
-    unit.pass();
-  });
 }
 
 function testRender(unit, source, context, expected, options, baseContext, error, logMessage, config) {

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -2052,43 +2052,29 @@ var coreTests = [
         name:     "non-existing helper",
         source:   "some text {@notfound}foo{/notfound} some text",
         context:  {},
-        log: "Invalid helper [notfound]",
+        log: "Helper `notfound` does not exist",
         message: "Should crash the application if a helper is not found"
       },
       {
         name:     "invalid filter",
         source:   "{obj|nullcheck|invalid}",
         context:  { obj: "test" },
-        log:    "Invalid filter [nullcheck]",
+        log:    "Invalid filter `nullcheck`",
         message: "should fail hard for invalid filter"
       },
       {
         name: "Reference not found",
-        source:"{wrongTest}",
+        source:"{wrong.test}",
         context: {"test": "example text"},
-        log: "Cannot find the value for reference [{wrongTest}] in template [Reference not found]",
+        log: "Cannot find reference `{wrong.test}` in template `Reference not found`",
         message: "test the log messages for a reference not found."
       },
       {
-        name: "Unhandled section tag",
+        name: "Section not found",
         source:"{#strangeSection}{/strangeSection}",
         context: {"test": "example text"},
-        log: "Not rendering section (#) block in template [Unhandled section tag], because above key was not found",
+        log: "Section without corresponding key in template `Section not found`",
         message: "test the log messages for an unhandled section."
-      },
-      {
-        name: "No render for exists",
-        source:"{?doesNotExist}{/doesNotExist}",
-        context: {},
-        log: "Not rendering exists (?) block in template [No render for exists], because above key was not found",
-        message: "test the log messages for a non existing exists check."
-      },
-      {
-        name: "No render for not exists",
-        source:"{^exists}{/exists}",
-        context: {"exists": "example text"},
-        log: "Not rendering not exists (^) block check in template [No render for not exists], because above key was found",
-        message: "test the log messages for an existing not exists check."
       },
       {
         name: "Errors should be throwable from helpers and consumed in the render callback/stream onerror",

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -2076,7 +2076,21 @@ var coreTests = [
         log: "Section without corresponding key in template `Section not found`",
         message: "test the log messages for an unhandled section."
       },
-      {
+	  {
+		name: "Exists without body",
+		source: "{?foo/}",
+		context: {"foo": "foo"},
+		log: "No block for exists check in template `Exists without body`",
+		message: "test the log message for an exists block with no body"
+	  },
+	  {
+		name: "Not exists without body",
+		source: "{^foo/}",
+		context: {},
+		log: "No block for not-exists check in template `Not exists without body`",
+		message: "test the log message for a not-exists block with no body"
+	  },
+	  {
         name: "Errors should be throwable from helpers and consumed in the render callback/stream onerror",
         source: "{@error errorMessage=\"helper error\"}{/error}",
         context: { },

--- a/test/jasmine-test/spec/renderTestSpec.js
+++ b/test/jasmine-test/spec/renderTestSpec.js
@@ -1,3 +1,4 @@
+/*global dust*/
 describe ('Test the basic functionality of dust', function() {
   for (var index = 0; index < coreTests.length; index++) {
     for (var i = 0; i < coreTests[index].tests.length; i++) {
@@ -6,15 +7,20 @@ describe ('Test the basic functionality of dust', function() {
       it ('STREAM: ' + test.message, stream(test));
       it ('PIPE: ' + test.message, pipe(test));
     }
-  };
+  }
 });
+
+// Absorb all logs into a log queue for testing purposes
+dust.logQueue = [];
+dust.log = function(msg, type) {
+  dust.logQueue.push({ message: msg, type: type });
+};
 
 function render(test) {
   return function() {
     var messageInLog = false;
     var context;
     try {
-      dust.isDebug = !!(test.error || test.log);
       dust.debugLevel = 'DEBUG';
       dust.config = test.config || { whitespace: false };
       dust.loadSource(dust.compile(test.source, test.name, test.strip));
@@ -39,7 +45,6 @@ function render(test) {
               break;
             }
           }
-          dust.logQueue = [];
           expect(messageInLog).toEqual(true);
         } else {
           expect(test.expected).toEqual(output);
@@ -64,7 +69,6 @@ function stream(test) {
       output = '';
       log = [];
       try {
-        dust.isDebug = !!(test.error || test.log);
         dust.debugLevel = 'DEBUG';
         dust.config = test.config || { whitespace: false };
         dust.loadSource(dust.compile(test.source, test.name));
@@ -154,7 +158,6 @@ function pipe(test) {
       messageInLog = false;
       messageInLogTwo = false;
       try {
-        dust.isDebug = !!(test.error || test.log);
         dust.debugLevel = 'DEBUG';
         dust.config = test.config || { whitespace: false };
         dust.loadSource(dust.compile(test.source, test.name));

--- a/test/server.js
+++ b/test/server.js
@@ -3,10 +3,16 @@ var uutest    = require('./uutest'),
     coreTests     = require('./jasmine-test/spec/coreTests'),
     coreSetup = require('./core').coreSetup;
 
-//make dust a global
-dust = require('../lib/server');
-//load additional helpers used in testing
+var dust = require('../lib/server');
+
+// load additional helpers used in testing
 require('./jasmine-test/spec/testHelpers');
+
+// Absorb all logs into a log queue for testing purposes
+dust.logQueue = [];
+dust.log = function(msg, type) {
+  dust.logQueue.push({ message: msg, type: type });
+};
 
 function dumpError(err) {
   var out = err.testName + ' -> ';
@@ -26,8 +32,6 @@ for (var i=0; i<coreTests.length; i++) {
       process.stdout.write("F");
     },
     done: function(passed, failed, elapsed) {
-      process.stdout.write('\n');
-      console.log(passed + ' passed ' + failed + ' failed ' + '(' + elapsed + 'ms)');
       this.errors.forEach(function(err) {
         console.log(dumpError(err));
         process.exit(1);


### PR DESCRIPTION
Similar to linkedin/dustjs-helpers#119

Normalizes all log messages, removes some spew, fixes some logs that would never be logged, and removes the indexOf shim in favor of a map lookup.

Closes #485 