### PR TITLE
Move lib/server to index

### DIFF
--- a/bin/dustc
+++ b/bin/dustc
@@ -2,7 +2,7 @@
 
 var cli = require('cli').enable('glob', 'version'),
     watcher = require('chokidar'),
-    dust = require('../lib/server.js'),
+    dust = require('..'),
     fs = cli.native.fs,
     path = cli.native.path,
     eol = cli.native.os.EOL;

--- a/bower.json
+++ b/bower.json
@@ -44,6 +44,7 @@
     "src",
     "test",
     "tmp",
+    "index.js",
     "Gruntfile.js",
     "package.json"
   ]

--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
 /*global process*/
-var path = require('path'),
-    vm = require('vm'),
-    dust = require('./dust'),
-    parser = require('./parser'),
-    compiler = require('./compiler');
-
+var vm = require('vm'),
+    dust = require('./lib/dust.js'),
+    parser = require('./lib/parser.js'),
+    compiler = require('./lib/compiler.js');
 
 // use Node equivalents for some Dust methods
 var context = vm.createContext({dust: dust});

--- a/lib/README.md
+++ b/lib/README.md
@@ -14,26 +14,23 @@ The Dust project consists of 3 parts:
  * **compiler.js** - responsible for taking Dust AST and turning it into Javscript functions that can be `dust.render`'ed
 
 
-### server.js
-There is one more file in lib: **server.js** (see package.json). This file is the entry point for Node environments.
-
 ### dust-core pre-compiling files and keeping a slim runtime
 For browser performance, we recommend providing only the **dust-core.js** file to the browser and compiling templates on the server.
 
 You can think of **dust-core.js** as the runtime file. Currently, core only include **dust.js** which provides enough to render basic templates in the browser(without helpers; for templates with helpers see the dustjs-helpers repo).
 
 ### dust-full when you need to compile
-When you need to compile templates, that is take files written in Dust syntax and converting them to things that can be `dust.render`'ed, you'll need **dust-full.js**.  The **compiler.js** and **parser.js** file are included with **dust.js** in **dust-full.js** in order to provide the compile functionality. 
+When you need to compile templates, that is take files written in Dust syntax and converting them to things that can be `dust.render`'ed, you'll need **dust-full.js**.  The **compiler.js** and **parser.js** file are included with **dust.js** in **dust-full.js** in order to provide the compile functionality.
 
 You should provide **dust-full.js** to the browser if you are compiling templates on demand or if simply just don't want to pre-compile on the server and perf does not matter.
 
 If you are using Node and using `require('dustjs-linkedin')` you are getting dust-full.
 
 ### Server vs Browser - the server file
-Dust is written to run on both the server and the browser. In truth, it is written to work first on the browser and modified to work on the server. 
+Dust is written to run on both the server and the browser. In truth, it is written to work first on the browser and modified to work on the server.
 
 A few things are added to make it work on the server:
 
  * A UMD style wrapper is added to all the files so that, for example, `dust` is returned to `module.exports` in Node whereas it would have returned as `window.dust` in the browser
- * Servers that use npm (Node) need a single main entry point. For us, this is **server.js**  which sets up `dust-full` by pulling in the necessary lib modules, modifies some methods to work in Node, and exports it as a module.
+ * Servers that use npm (Node) need a single main entry point. For us, this is **index.js**  which sets up `dust-full` by pulling in the necessary lib modules, modifies some methods to work in Node, and exports it as a module.
  * Browsers don't need to be a single file but to make it easier a build script is setup so that the necessary lib files are combined into **dist/dust-full.js** and **dist/dust-core.js**.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "bin": {
     "dustc": "./bin/dustc"
   },
-  "main": "lib/server.js",
+  "main": "index.js",
   "browser": "./lib/dust.js",
   "repository": {
     "type": "git",

--- a/test/server.js
+++ b/test/server.js
@@ -3,7 +3,7 @@ var uutest    = require('./uutest'),
     coreTests     = require('./jasmine-test/spec/coreTests'),
     coreSetup = require('./core').coreSetup;
 
-var dust = require('../lib/server');
+var dust = require('..');
 
 // load additional helpers used in testing
 require('./jasmine-test/spec/testHelpers');


### PR DESCRIPTION
This is the most common Node convention. It also makes it very clear that the `server.js` file is for Node by moving it away from the `lib` directory.