### PR TITLE
Allow Rhino test failures to break the build (and fix a test typo that broke Rhino)

### DIFF
--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -1146,7 +1146,7 @@ var coreTests = [
 	  {
 		name:	  "partial with async ref as name",
 		source:   '{>"{ref}" /}',
-		context:  { ref: function(chunk, context) { return chunk.map(function(chunk) { setTimeout(function() { chunk.end('hello_world'); }) }); }},
+		context:  { ref: function(chunk, context) { return chunk.map(function(chunk) { setTimeout(function() { chunk.end('hello_world'); }, 0) }); }},
 		expected: "Hello World!",
 		message:  "should test partial with an asynchronously-resolved template name"
 	  },

--- a/test/rhino/rhinoTest.js
+++ b/test/rhino/rhinoTest.js
@@ -71,7 +71,7 @@ reporter.reportSuiteResults = function (suite) {
   print('Passed ' + passed + ' Failed ' + failed.length + '\n');
 
   if(failed.length > 0) {
-    throw 'There are failing tests.';
+    java.lang.System.exit(1);
   } else {
     quit();
   }


### PR DESCRIPTION
Right now even if Rhino fails, the build succeeds. Guess no one ever broke just Rhino before.

(However, Dust itself was never broken, just the unit tests.)