### PR TITLE
Add grunt-github-changes plugin to automatically update changelog before releases

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -240,6 +240,17 @@ module.exports = function(grunt) {
                     '  * npm publish'].join('\n')
         }
       }
+    },
+    githubChanges: {
+      dist: {
+        options: {
+          owner: "linkedin",
+          repository: "dustjs",
+          onlyPulls: true,
+          useCommitBody: true,
+          auth: true
+        }
+      }
     }
   });
 
@@ -266,6 +277,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-bump');
   grunt.loadNpmTasks('grunt-shell');
   grunt.loadNpmTasks('grunt-jasmine-nodejs');
+  grunt.loadNpmTasks('grunt-github-changes');
 
   //--------------------------------------------------
   //------------Grunt task aliases -------------------
@@ -291,7 +303,7 @@ module.exports = function(grunt) {
 
   //release tasks
   grunt.registerTask('copyForRelease', ['clean:dist', 'copy:core', 'copy:coreMin', 'copy:full', 'copy:fullMin', 'copy:license', 'log:copyForRelease']);
-  grunt.registerTask('buildRelease',   ['test', 'copyForRelease']);
+  grunt.registerTask('buildRelease',   ['test', 'githubChanges', 'copyForRelease']);
   grunt.registerTask('releasePatch',   ['bump-only:patch', 'buildRelease', 'bump-commit', 'log:release']);
   grunt.registerTask('releaseMinor',   ['bump-only:minor', 'buildRelease', 'bump-commit', 'log:release']);
   // major release should probably be done with care

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "grunt-contrib-uglify": "~0.8.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-gh-pages": "~0.10.0",
+    "grunt-github-changes": "~0.0.6",
     "grunt-jasmine-nodejs": "~1.0.2",
     "grunt-shell": "~1.1.2",
     "grunt-template-jasmine-istanbul": "~0.3.3",


### PR DESCRIPTION
Tested to confirm that the generated changelog is the same as before.

Closes #600 