### PR TITLE
Refactor template compilation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -181,6 +181,17 @@ module.exports = function(grunt) {
       }
     },
     jasmine_nodejs: {
+      cjs: {
+        specs: ['test/jasmine-test/spec/cjsSpec.js'],
+        options: {
+          reporters: {
+            console: {
+              colors: false,
+              verbose: false
+            }
+          }
+        }
+      },
       dustc: {
         specs: ['test/jasmine-test/spec/cli/*'],
         options: {
@@ -286,11 +297,11 @@ module.exports = function(grunt) {
   grunt.registerTask('build',          ['clean:build', 'shell:buildParser', 'buildLib', 'uglify']);
 
   //test tasks
-  grunt.registerTask('testNode',       ['shell:oldTests']);
+  grunt.registerTask('testNode',       ['jasmine_nodejs:cjs', 'shell:oldTests']);
   grunt.registerTask('testRhino',      ['build', 'shell:testRhino']);
   grunt.registerTask('testPhantom',    ['build', 'jasmine:testProd']);
   grunt.registerTask('testCli',        ['build', 'jasmine_nodejs:dustc']);
-  grunt.registerTask('test',           ['build', 'jasmine:testProd', 'jasmine_nodejs:dustc', 'shell:oldTests', 'shell:testRhino', 'jasmine:coverage']);
+  grunt.registerTask('test',           ['build', 'jasmine:testProd', 'jasmine_nodejs:dustc', 'jasmine_nodejs:cjs', 'shell:oldTests', 'shell:testRhino', 'jasmine:coverage']);
 
   //task for debugging in browser
   grunt.registerTask('dev',            ['build', 'jasmine:testDev:build', 'connect:testServer','log:testClient', 'watch:lib']);

--- a/bin/dustc
+++ b/bin/dustc
@@ -22,6 +22,7 @@ cli.parse({
     pwd:        [false, 'generate template names starting from this directory',                                     'string'],
     whitespace: ['w',   'preserve whitespace in templates',                                                                 ],
     amd:        ['a',   'register templates as AMD modules'                                                                 ],
+    cjs:        [false, 'register templates as CommonJS modules (automatically turns on --split)'                           ],
     watch:      [false, 'watch files for changes and recompile'                                                             ]
 });
 
@@ -30,7 +31,7 @@ cli.parse({
  */
 if (!cli.argc) {
     if (!cli.options.name) {
-        cli.getUsage();
+        cli.info('No template name provided. The compiled template will be anonymous.');
     }
     cli.info('No files to compile. Write template code and use ^D to exit');
     cli.withStdin(function(data) {
@@ -58,6 +59,14 @@ function handle() {
                 templateName = path.join(path.dirname(inputFile),
                                          path.basename(inputFile, path.extname(inputFile))),
                 compiledData;
+
+            // If CommonJS is turned on, you have to compile one per file.
+            if (cli.options.cjs && filesToProcess.length > 1) {
+                if(!cli.options.split) {
+                    cli.info('CommonJS modules are limited to one per file. Enabling --split');
+                }
+                cli.options.split = true;
+            }
 
             // Use the template's path as the output path if split-files is turned on
             if (cli.options.split) {
@@ -131,6 +140,7 @@ function compile(data, name) {
 
     dust.config.whitespace = (cli.options.whitespace === true);
     dust.config.amd = (cli.options.amd === true);
+    dust.config.cjs = (cli.options.cjs === true);
 
     try {
         compiled = dust.compile(data, name);

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ var vm = require('vm'),
 
 // use Node equivalents for some Dust methods
 var context = vm.createContext({dust: dust});
-dust.loadSource = function(source, path) {
-  return vm.runInContext(source, context, path);
+dust.loadSource = function(source) {
+  return vm.runInContext(source, context);
 };
 
 dust.nextTick = process.nextTick;

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -22,9 +22,6 @@
     // for templates that are compiled as a callable (compileFn)
     //
     // for the common case (using compile and render) a name is required so that templates will be cached by name and rendered later, by name.
-    if (!name && name !== null) {
-      throw new Error('Template name parameter cannot be undefined when calling dust.compile');
-    }
 
     try {
       var ast = filterAST(parse(source));
@@ -164,18 +161,21 @@
       auto: 'h'
     },
     escapedName = dust.escapeJs(name),
-    body_0 = 'function(dust){dust.register(' +
-        (name ? '"' + escapedName + '"' : 'null') + ',' +
-        compiler.compileNode(context, ast) +
-        ');' +
-        compileBlocks(context) +
-        compileBodies(context) +
-        'return body_0;}';
+    compiled = '';
+
+    compiler.compileNode(context, ast);
+
+    if(name) {
+      compiled += 'dust.register("' + escapedName + '",body_0);';
+    }
+
+    compiled += compileBlocks(context) +
+                compileBodies(context);
 
     if(dust.config.amd) {
-      return 'define("' + escapedName + '",["dust.core"],' + body_0 + ');';
+      return 'define("' + escapedName + '",["dust.core"],function(dust){' + compiled + 'return body_0});';
     } else {
-      return '(' + body_0 + ')(dust);';
+      return '(function(dust){' + compiled + 'return body_0})(dust);';
     }
   }
 
@@ -427,13 +427,19 @@
                   function(str) { return '"' + escapeToJsSafeString(str) + '"';} :
                   JSON.stringify;
 
+  function renderSource(source, context, callback) {
+    var tmpl = dust.loadSource(dust.compile(source));
+    if(callback) {
+      return dust.render(tmpl, context, callback);
+    } else {
+      return dust.stream(tmpl, context);
+    }
+  }
+
   // expose compiler methods
-  dust.compile = compiler.compile;
-  dust.filterNode = compiler.filterNode;
-  dust.optimizers = compiler.optimizers;
-  dust.pragmas = compiler.pragmas;
-  dust.compileNode = compiler.compileNode;
-  dust.nodes = compiler.nodes;
+  dust.compiler = compiler;
+  dust.compile = dust.compiler.compile;
+  dust.renderSource = renderSource;
 
   return compiler;
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -74,7 +74,7 @@
   };
 
   compiler.pragmas = {
-    esc: function(compiler, context, bodies, params) {
+    esc: function(compiler, context, bodies) {
       var old = compiler.auto,
           out;
       if (!context) {
@@ -161,8 +161,8 @@
       auto: 'h'
     },
     escapedName = dust.escapeJs(name),
-    AMDName = name? '"' + escapedName + '",' : '';
-    compiled = '',
+    AMDName = name? '"' + escapedName + '",' : '',
+    compiled = 'function(dust){',
     entry = compiler.compileNode(context, ast);
 
     if(name) {
@@ -171,14 +171,14 @@
 
     compiled += compileBlocks(context) +
                 compileBodies(context) +
-                'return ' + entry;
+                'return ' + entry + '}';
 
     if(dust.config.amd) {
-      return 'define(' + AMDName + '["dust.core"],function(dust){' + compiled + '});';
+      return 'define(' + AMDName + '["dust.core"],' + compiled + ');';
     } else if(dust.config.cjs) {
-      return 'module.exports=function(dust){' + compiled + '}';
+      return 'module.exports=' + compiled;
     } else {
-      return '(function(dust){' + compiled + '})(dust);';
+      return '(' + compiled + '(dust));';
     }
   }
 
@@ -443,6 +443,13 @@
   dust.compiler = compiler;
   dust.compile = dust.compiler.compile;
   dust.renderSource = renderSource;
+
+  // DEPRECATED legacy names. Removed in 2.8.0
+  dust.filterNode = compiler.filterNode;
+  dust.optimizers = compiler.optimizers;
+  dust.pragmas = compiler.pragmas;
+  dust.compileNode = compiler.compileNode;
+  dust.nodes = compiler.nodes;
 
   return compiler;
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -270,13 +270,13 @@
 
     '+': function(context, node) {
       if (typeof(node[1].text) === 'undefined'  && typeof(node[4]) === 'undefined'){
-        return '.block(ctx.getBlock(' +
+        return '.b(ctx.getBlock(' +
               compiler.compileNode(context, node[1]) +
               ',chk, ctx),' + compiler.compileNode(context, node[2]) + ', {},' +
               compiler.compileNode(context, node[3]) +
               ')';
       } else {
-        return '.block(ctx.getBlock(' +
+        return '.b(ctx.getBlock(' +
             escape(node[1].text) +
             '),' + compiler.compileNode(context, node[2]) + ',' +
             compiler.compileNode(context, node[4]) + ',' +

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -163,7 +163,8 @@
     escapedName = dust.escapeJs(name),
     AMDName = name? '"' + escapedName + '",' : '',
     compiled = 'function(dust){',
-    entry = compiler.compileNode(context, ast);
+    entry = compiler.compileNode(context, ast),
+    iife;
 
     if(name) {
       compiled += 'dust.register("' + escapedName + '",' + entry + ');';
@@ -173,12 +174,17 @@
                 compileBodies(context) +
                 'return ' + entry + '}';
 
+    iife = '(' + compiled + '(dust));';
+
     if(dust.config.amd) {
       return 'define(' + AMDName + '["dust.core"],' + compiled + ');';
     } else if(dust.config.cjs) {
-      return 'module.exports=' + compiled;
+      return 'module.exports=function(dust){' +
+             'var tmpl=' + iife +
+             'var f=' + loaderFor().toString() + ';' +
+             'f.template=tmpl;return f}';
     } else {
-      return '(' + compiled + '(dust));';
+      return iife;
     }
   }
 
@@ -432,21 +438,18 @@
 
   function renderSource(source, context, callback) {
     var tmpl = dust.loadSource(dust.compile(source));
-    if(callback) {
-      return dust.render(tmpl, context, callback);
-    } else {
-      return dust.stream(tmpl, context);
-    }
+    return loaderFor(tmpl)(context, callback);
   }
 
   function compileFn(source, name) {
     var tmpl = dust.loadSource(dust.compile(source, name));
-    return function(context, callback) {
-      if(callback) {
-        return dust.render(tmpl, context, callback);
-      } else {
-        return dust.stream(tmpl, context);
-      }
+    return loaderFor(tmpl);
+  }
+
+  function loaderFor(tmpl) {
+    return function load(ctx, cb) {
+      var fn = cb ? 'render' : 'stream';
+      return dust[fn](tmpl, ctx, cb);
     };
   }
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -161,21 +161,24 @@
       auto: 'h'
     },
     escapedName = dust.escapeJs(name),
-    compiled = '';
-
-    compiler.compileNode(context, ast);
+    AMDName = name? '"' + escapedName + '",' : '';
+    compiled = '',
+    entry = compiler.compileNode(context, ast);
 
     if(name) {
-      compiled += 'dust.register("' + escapedName + '",body_0);';
+      compiled += 'dust.register("' + escapedName + '",' + entry + ');';
     }
 
     compiled += compileBlocks(context) +
-                compileBodies(context);
+                compileBodies(context) +
+                'return ' + entry;
 
     if(dust.config.amd) {
-      return 'define("' + escapedName + '",["dust.core"],function(dust){' + compiled + 'return body_0});';
+      return 'define(' + AMDName + '["dust.core"],function(dust){' + compiled + '});';
+    } else if(dust.config.cjs) {
+      return 'module.exports=function(dust){' + compiled + '}';
     } else {
-      return '(function(dust){' + compiled + 'return body_0})(dust);';
+      return '(function(dust){' + compiled + '})(dust);';
     }
   }
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -439,10 +439,22 @@
     }
   }
 
+  function compileFn(source, name) {
+    var tmpl = dust.loadSource(dust.compile(source, name));
+    return function(context, callback) {
+      if(callback) {
+        return dust.render(tmpl, context, callback);
+      } else {
+        return dust.stream(tmpl, context);
+      }
+    };
+  }
+
   // expose compiler methods
   dust.compiler = compiler;
   dust.compile = dust.compiler.compile;
   dust.renderSource = renderSource;
+  dust.compileFn = compileFn;
 
   // DEPRECATED legacy names. Removed in 2.8.0
   dust.filterNode = compiler.filterNode;

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -114,7 +114,7 @@
     if(!nameOrTemplate) {
       return chunk.setError(new Error('No template or template name provided to render'));
     }
-    var tmpl = nameOrTemplate.__dustBody ? nameOrTemplate : dust.cache[nameOrTemplate],
+    var tmpl = dust.isTemplateFn(nameOrTemplate) ? nameOrTemplate : dust.cache[nameOrTemplate],
         templateName = tmpl.templateName;
     if (tmpl) {
       return tmpl(chunk, Context.wrap(context, templateName));
@@ -153,7 +153,7 @@
     return function(callback) {
       setTimeout(callback, 0);
     };
-  } )();
+  })();
 
   /**
    * Dust has its own rules for what is "empty"-- which is not the same as falsy.
@@ -186,6 +186,11 @@
       }
     }
     return true;
+  };
+
+  dust.isTemplateFn = function(elem) {
+    return typeof elem === 'function' &&
+           elem.__dustBody;
   };
 
   /**
@@ -700,7 +705,7 @@
         chunk = this,
         i, len;
 
-    if (typeof elem === 'function' && !elem.__dustBody) {
+    if (typeof elem === 'function' && !dust.isTemplateFn(elem)) {
       try {
         elem = elem.apply(context.current(), [this, context, bodies, params]);
       } catch(err) {
@@ -821,7 +826,7 @@
                        .push(head);
     }
 
-    if (elem.__dustBody) {
+    if (dust.isTemplateFn(elem)) {
       // The eventual result of evaluating `elem` is a partial name
       // Load the partial after getting its name and end the async chunk
       return this.capture(elem, context, function(name, chunk) {

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -16,7 +16,8 @@
 
   dust.config = {
     whitespace: false,
-    amd: false
+    amd: false,
+    cache: true
   };
 
   // Directive aliases to minify code
@@ -114,6 +115,11 @@
     if(!nameOrTemplate) {
       return chunk.setError(new Error('No template or template name provided to render'));
     }
+
+    if(!dust.config.cache) {
+      dust.cache = {};
+    }
+
     var tmpl = dust.isTemplateFn(nameOrTemplate) ? nameOrTemplate : dust.cache[nameOrTemplate],
         templateName = tmpl.templateName;
     if (tmpl) {

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -120,10 +120,9 @@
       dust.cache = {};
     }
 
-    var tmpl = dust.isTemplateFn(nameOrTemplate) ? nameOrTemplate : dust.cache[nameOrTemplate],
-        templateName = tmpl.templateName;
+    var tmpl = dust.isTemplateFn(nameOrTemplate) ? nameOrTemplate : dust.cache[nameOrTemplate];
     if (tmpl) {
-      return tmpl(chunk, Context.wrap(context, templateName));
+      return tmpl(chunk, Context.wrap(context, tmpl.templateName));
     } else {
       if (dust.onLoad) {
         return chunk.map(function(chunk) {

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -121,7 +121,18 @@
       dust.cache = {};
     }
 
-    var tmpl = dust.isTemplateFn(nameOrTemplate) ? nameOrTemplate : dust.cache[nameOrTemplate];
+    var tmpl;
+    if(typeof nameOrTemplate === 'function' && nameOrTemplate.template) {
+      // Sugar away CommonJS module templates
+      tmpl = nameOrTemplate.template;
+    } else if(dust.isTemplateFn(nameOrTemplate)) {
+      // Template functions passed directly
+      tmpl = nameOrTemplate;
+    } else {
+      // Load a template with this name from cache
+      tmpl = dust.cache[nameOrTemplate];
+    }
+
     if (tmpl) {
       return tmpl(chunk, Context.wrap(context, tmpl.templateName));
     } else {

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -87,10 +87,10 @@
     dust.cache[name] = tmpl;
   };
 
-  dust.render = function(name, context, callback) {
+  dust.render = function(nameOrTemplate, context, callback) {
     var chunk = new Stub(callback).head;
     try {
-      dust.load(name, chunk, Context.wrap(context, name)).end();
+      dust.load(nameOrTemplate, chunk, Context.wrap(context, nameOrTemplate)).end();
     } catch (err) {
       chunk.setError(err);
     }
@@ -136,25 +136,25 @@
     };
   };
 
-  dust.load = function(name, chunk, context) {
-    var tmpl = dust.cache[name];
+  dust.load = function(nameOrTemplate, chunk, context) {
+    var tmpl = nameOrTemplate.__dustBody ? nameOrTemplate : dust.cache[nameOrTemplate];
     if (tmpl) {
       return tmpl(chunk, context);
     } else {
       if (dust.onLoad) {
         return chunk.map(function(chunk) {
-          dust.onLoad(name, function(err, src) {
+          dust.onLoad(nameOrTemplate, function(err, src) {
             if (err) {
               return chunk.setError(err);
             }
-            if (!dust.cache[name]) {
-              dust.loadSource(dust.compile(src, name));
+            if (!dust.cache[nameOrTemplate]) {
+              dust.loadSource(dust.compile(src, nameOrTemplate));
             }
-            dust.cache[name](chunk, context).end();
+            dust.cache[nameOrTemplate](chunk, context).end();
           });
         });
       }
-      return chunk.setError(new Error('Template Not Found: ' + name));
+      return chunk.setError(new Error('Template Not Found: ' + nameOrTemplate));
     }
   };
 

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -17,6 +17,7 @@
   dust.config = {
     whitespace: false,
     amd: false,
+    cjs: false,
     cache: true
   };
 

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -84,24 +84,25 @@
     if (!name) {
       return;
     }
+    tmpl.templateName = name;
     dust.cache[name] = tmpl;
   };
 
   dust.render = function(nameOrTemplate, context, callback) {
     var chunk = new Stub(callback).head;
     try {
-      dust.load(nameOrTemplate, chunk, Context.wrap(context, nameOrTemplate)).end();
+      load(nameOrTemplate, chunk, context).end();
     } catch (err) {
       chunk.setError(err);
     }
   };
 
-  dust.stream = function(name, context) {
+  dust.stream = function(nameOrTemplate, context) {
     var stream = new Stream(),
         chunk = stream.head;
     dust.nextTick(function() {
       try {
-        dust.load(name, stream.head, Context.wrap(context, name)).end();
+        load(nameOrTemplate, chunk, context).end();
       } catch (err) {
         chunk.setError(err);
       }
@@ -109,37 +110,14 @@
     return stream;
   };
 
-  dust.renderSource = function(source, context, callback) {
-    return dust.compileFn(source)(context, callback);
-  };
-
-  /**
-   * Compile a template to an invokable function.
-   * If `name` is provided, also registers the template under `name`.
-   * @param source {String} template source
-   * @param [name] {String} template name
-   * @return {Function} has the signature `fn(context, cb)`
-   */
-  dust.compileFn = function(source, name) {
-    name = name || null;
-    var tmpl = dust.loadSource(dust.compile(source, name));
-    return function(context, callback) {
-      var master = callback ? new Stub(callback) : new Stream();
-      dust.nextTick(function() {
-        if(typeof tmpl === 'function') {
-          tmpl(master.head, Context.wrap(context, name)).end();
-        } else {
-          dust.log(new Error('Template `' + name + '` could not be loaded'), ERROR);
-        }
-      });
-      return master;
-    };
-  };
-
-  dust.load = function(nameOrTemplate, chunk, context) {
-    var tmpl = nameOrTemplate.__dustBody ? nameOrTemplate : dust.cache[nameOrTemplate];
+  function load(nameOrTemplate, chunk, context) {
+    if(!nameOrTemplate) {
+      return chunk.setError(new Error('No template or template name provided to render'));
+    }
+    var tmpl = nameOrTemplate.__dustBody ? nameOrTemplate : dust.cache[nameOrTemplate],
+        templateName = tmpl.templateName;
     if (tmpl) {
-      return tmpl(chunk, context);
+      return tmpl(chunk, Context.wrap(context, templateName));
     } else {
       if (dust.onLoad) {
         return chunk.map(function(chunk) {
@@ -150,13 +128,13 @@
             if (!dust.cache[nameOrTemplate]) {
               dust.loadSource(dust.compile(src, nameOrTemplate));
             }
-            dust.cache[nameOrTemplate](chunk, context).end();
+            dust.cache[nameOrTemplate](chunk, Context.wrap(context, nameOrTemplate)).end();
           });
         });
       }
       return chunk.setError(new Error('Template Not Found: ' + nameOrTemplate));
     }
-  };
+  }
 
   dust.loadSource = function(source) {
     /*jshint evil:true*/
@@ -173,7 +151,7 @@
 
   dust.nextTick = (function() {
     return function(callback) {
-      setTimeout(callback,0);
+      setTimeout(callback, 0);
     };
   } )();
 
@@ -848,11 +826,11 @@
       // Load the partial after getting its name and end the async chunk
       return this.capture(elem, context, function(name, chunk) {
         context.templateName = name;
-        dust.load(name, chunk, context).end();
+        load(name, chunk, context).end();
       });
     } else {
       context.templateName = elem;
-      return dust.load(elem, this, context);
+      return load(elem, this, context);
     }
   };
 

--- a/test/core.js
+++ b/test/core.js
@@ -98,6 +98,36 @@ exports.coreSetup = function(suite, auto) {
     });
   });
 
+  suite.test("compileFn", function() {
+    var unit = this,
+        tmpl = dust.compileFn('Hello {world}');
+    tmpl({world: "World"}, function(err, out) {
+      try {
+        unit.ifError(err);
+        unit.equals(out, "Hello World");
+      } catch(err) {
+        unit.fail(err);
+        return;
+      }
+      unit.pass();
+    });
+  });
+
+  suite.test("compileFn stream", function() {
+    var unit = this,
+        tmpl = dust.compileFn('Hello {world}');
+    tmpl({world: "World"})
+    .on('data', function(out) {
+      try {
+        unit.equals(out, "Hello World");
+      } catch(err) {
+        unit.fail(err);
+        return;
+      }
+      unit.pass();
+    });
+  });
+
   suite.test("renderSource (stream)", function() {
     var unit = this;
     dust.renderSource('Hello World', {}).on('data', function(data) {

--- a/test/core.js
+++ b/test/core.js
@@ -49,21 +49,6 @@ exports.coreSetup = function(suite, auto) {
     });
   });
 
-  suite.test("compileFn", function() {
-    var unit = this,
-        tmpl = dust.compileFn('Hello World');
-    tmpl({}, function(err, out) {
-      try {
-        unit.ifError(err);
-        unit.equals(out, "Hello World");
-      } catch(err) {
-        unit.fail(err);
-        return;
-      }
-      unit.pass();
-    });
-  });
-
   suite.test("renderSource (stream)", function() {
     var unit = this;
     dust.renderSource('Hello World', {}).on('data', function(data) {

--- a/test/jasmine-test/spec/cjsSpec.js
+++ b/test/jasmine-test/spec/cjsSpec.js
@@ -1,0 +1,59 @@
+/*global describe,expect,it,beforeEach */
+/*jshint evil:true*/
+var dust = require('../../../');
+
+function load(tmpl) {
+  dust.config.cjs = true;
+  return eval(dust.compile(tmpl, 'hello'))(dust);
+}
+
+describe('CommonJS template', function() {
+  var template = "Hello {world}!",
+      context = { world: "world" },
+      rendered = "Hello world!",
+      templateName = 'hello',
+      tmpl;
+
+  beforeEach(function() {
+    tmpl = load(template);
+  });
+
+  it('can be invoked to render', function() {
+    tmpl(context, function(err, out) {
+      expect(out).toEqual(rendered);
+    });
+  });
+
+  it('can be invoked to stream', function(done) {
+    tmpl(context).on('data', function(out) {
+      expect(out).toEqual(rendered);
+      done();
+    });
+  });
+
+  it('can be passed to dust.render', function() {
+    dust.render(tmpl, context, function(err, out) {
+      expect(out).toEqual(rendered);
+    });
+  });
+
+  it('can be passed to dust.stream', function(done) {
+    dust.stream(tmpl, context).on('data', function(out) {
+      expect(out).toEqual(rendered);
+      done();
+    });
+  });
+
+  it('has a template property that can be passed to dust.render', function() {
+    expect(tmpl.template.templateName).toEqual(templateName);
+    dust.render(tmpl.template, context, function(err, out) {
+      expect(out).toEqual(rendered);
+    });
+  });
+
+  it('has a name that can be passed to dust.render', function() {
+    dust.render(templateName, context, function(err, out) {
+      expect(out).toEqual(rendered);
+    });
+  });
+});

--- a/test/jasmine-test/spec/cli/cliSpec.js
+++ b/test/jasmine-test/spec/cli/cliSpec.js
@@ -1,3 +1,4 @@
+/*global describe,expect,it,afterEach */
 var path = require('path'),
     fs = require('fs'),
     exec = require('child_process').exec;

--- a/test/jasmine-test/spec/cli/cliSpec.js
+++ b/test/jasmine-test/spec/cli/cliSpec.js
@@ -13,18 +13,10 @@ require('./lib/matchers.js');
 
 describe('dustc', function() {
 
-it('outputs help text when run with no arguments', function(done) {
-  dustc('', function(err, stdout, stderr) {
-    expect(stderr).toMatch("Usage");
-    done();
-  });
-});
-
 describe('template piped from stdin', function() {
-  it('does not get compiled if no name is set', function(done) {
+  it('compiles anonymously if --name is not set', function(done) {
     dustc('< a.dust', function(err, stdout, stderr) {
-      expect(stdout).toBeFalsy();
-      expect(stderr).toMatch("Usage");
+      expect(stdout).toMatch(/function\(dust\)/g);
       done();
     });
   });
@@ -134,6 +126,26 @@ describe('--amd', function() {
       expect(stdout).toHaveAMDTemplate('a');
       expect(stdout).toHaveAMDTemplate('b');
       expect(stdout).toHaveAMDTemplate('two/2');
+      done();
+    });
+  });
+});
+
+describe('--cjs', function() {
+  it('compiles a single template as a CommonJS module', function(done) {
+    dustc('a.dust --cjs', function(err, stdout, stderr) {
+      expect(stdout).toHaveCJSTemplate('a');
+      done();
+    });
+  });
+  it('compiles several templates and splits', function(done) {
+    dustc('a.dust b.dust two/2.dust --cjs', function(err, stdout, stderr) {
+      expect(fixture('a.js')).toBeFileWithTemplate('a');
+      expect(fixture('b.js')).toBeFileWithTemplate('b');
+      expect(fixture('two/2.js')).toBeFileWithTemplate('two/2');
+      fs.unlinkSync(fixture('a.js'));
+      fs.unlinkSync(fixture('b.js'));
+      fs.unlinkSync(fixture('two/2.js'));
       done();
     });
   });

--- a/test/jasmine-test/spec/cli/lib/matchers.js
+++ b/test/jasmine-test/spec/cli/lib/matchers.js
@@ -32,6 +32,21 @@ matchers.toHaveAMDTemplate = function(util) {
   };
 };
 
+matchers.toHaveCJSTemplate = function(util) {
+  var dustCJSTemplateRegex = /module\.exports\=function\(dust\)\{/g;
+
+  return {
+    compare: function(actual, expected) {
+      var matches = [];
+      actual.replace(dustCJSTemplateRegex, function(whole, match) {
+        matches.push(match);
+      });
+      return { pass: matches.length &&
+                     matchers.toHaveTemplate().compare.call(this, actual, expected) };
+    }
+  };
+};
+
 matchers.toBeFileWithTemplate = function(util) {
   return {
     compare: function(actual, expected) {

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -70,12 +70,6 @@ var coreTests = [
         message: "should test the stream rendering"
       },
       {
-        name: undefined,
-        source: "compilation_failure",
-        error: "Template name parameter cannot be undefined when calling dust.compile",
-        message: "if the name is not there compilation should be failed, unless it is called from renderSource"
-      },
-      {
         name:     "hello_world",
         source:   "Hello World!",
         context:  {},

--- a/test/jasmine-test/spec/renderTestSpec.js
+++ b/test/jasmine-test/spec/renderTestSpec.js
@@ -32,7 +32,7 @@ describe ('Pipe', function() {
 });
 
 function prepare(test) {
-  dust.config = test.config || { whitespace: false };
+  dust.config = test.config || { whitespace: false, amd: false, cache: true };
   dust.loadSource(dust.compile(test.source, test.name));
   context = test.context;
   if (test.base) {

--- a/test/jasmine-test/spec/renderTestSpec.js
+++ b/test/jasmine-test/spec/renderTestSpec.js
@@ -32,7 +32,7 @@ describe ('Pipe', function() {
 });
 
 function prepare(test) {
-  dust.config = test.config || { whitespace: false, amd: false, cache: true };
+  dust.config = extend({ whitespace: false, amd: false, cache: true }, test.config);
   dust.loadSource(dust.compile(test.source, test.name));
   context = test.context;
   if (test.base) {
@@ -63,6 +63,14 @@ dust.log = function(msg, type) {
   dust.logQueue.push({ message: msg, type: type });
   dustLog.call(this, msg, type);
 };
+
+function extend(target, donor) {
+  donor = donor || {};
+  for(var prop in donor) {
+    target[prop] = donor[prop];
+  }
+  return target;
+}
 
 function render(test) {
   function checkRender(done) {


### PR DESCRIPTION
OK, there are quite a few changes in here.

This is the first step towards treating compiled templates as first-class citizens in Dust. We want to be able to pass around compiled templates and render them without having to worry about registering them under a specific name.

* `dust.render` and `dust.stream` now accept a compiled template function in addition to a template name.
* `dust.compile` no longer requires a template name, and will compile an anonymous template without one (so `--name` is no longer required for dustc either)
* `dust.load` is removed from the public API
* ~~`dust.compileFn` is removed completely~~
* `dust.renderSource` is moved to the compiler, so it's only included in dust-full now (Fixes #412)
* add `dust.isTemplateFn`
* add `dust.config.cache = true`, set to `false` to disable caching and load templates again every time (Fixes #451)
* add `dust.config.cjs = false`, set to `true` to compile templates as CommonJS modules for use like:

```
var dust = require('dustjs-linkedin');
var tmpl = require('tmpl/foo/bar.js')(dust);

tmpl({}, function() { ... });
dust.render(tmpl, {}, function() { ... });
tmpl.template // function body_0(){ ... }
```

* add `--cjs` flag to `dustc`
* Move a bunch of exposed compiler stuff under `dust.compiler` (but leave it exposed until 2.8)

Fixes #349 indirectly.
Closes #330 indirectly. [require.extensions is deprecated](https://nodejs.org/api/globals.html#globals_require_extensions) and the Node team recommends it not be used. The supported use case is going to be requiring compiled templates if you want, and hydrating them with a reference to Dust. This also lets you use multiple Dusts if you want, which is cool. Dust is not going to concern itself with how you load a template-- that's what `dust.onLoad` is for.