### PR TITLE
Fix behavior of `Context#resolve` when resolving a context function that returns a Chunk

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -469,10 +469,10 @@
       return body;
     }
     chunk = new Chunk().render(body, this);
-    if(!body.__dustBody) {
-      return chunk;
+    if(chunk instanceof Chunk) {
+      return chunk.data.join(''); // ie7 perf
     }
-    return chunk.data.join(''); // ie7 perf
+    return chunk;
   };
 
   Context.prototype.getTemplateName = function() {

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -267,26 +267,37 @@ var coreTests = [
       },
 	  {
 		name: "context.resolve",
-		source: "{#foo bar=\"{baz} is baz \" literal=\"literal \" func=func chunkFunc=\"{chunkFunc}\" ref=ref}Fail{/foo}",
+		source: ['{#foo',
+             'bar="{baz} is baz "',
+             'literal="literal "',
+             'func=func',
+             'chunkFunc="{chunkFunc}"',
+             'indirectChunkFunc=indirectChunkFunc',
+             'ref=ref',
+             '}Fail{/foo}'].join(' '),
 		context: {
 		  foo: function(chunk, context, bodies, params) {
-			chunk.write(context.resolve(params.bar));
-			chunk.write(context.resolve(params.literal));
-			chunk.write(context.resolve(params.func));
-			chunk.write(context.resolve(params.chunkFunc));
-			chunk.write(context.resolve(params.ref));
-			return chunk;
+  			chunk.write(context.resolve(params.bar));
+  			chunk.write(context.resolve(params.literal));
+  			chunk.write(context.resolve(params.func));
+        chunk.write(context.resolve(params.chunkFunc));
+        chunk.write(context.resolve(params.indirectChunkFunc));
+  			chunk.write(context.resolve(params.ref));
+  			return chunk;
 		  },
 		  baz: "baz",
 		  ref: "ref",
 		  func: function() {
-			return "func ";
+			  return "func ";
 		  },
 		  chunkFunc: function(chunk) {
-			return chunk.write('chunk ');
-		  }
+			  return chunk.write('chunk ');
+		  },
+      indirectChunkFunc: function(chunk) {
+        return chunk.write('indirect ');
+      }
 		},
-		expected: "baz is baz literal func chunk ref",
+		expected: "baz is baz literal func chunk indirect ref",
 		message: "context.resolve() taps parameters from the context"
 	  },
 	  {


### PR DESCRIPTION
There's one edge case that `context.resolve()` didn't hit.

If you have a function in context (not a generated Dust body function) that returns a chunk, the chunk is not evaluated.

```
{#foo param="{func_returns_chunk} world"/} {! works because the whole string turns into a generated body function !}
{#foo param=func_that_returns_value /} {! works because the func doesn't return a Chunk !}
{#foo param=func_that_returns_chunk /} {! [object Object] !}
```

PR fixes this edge case.