### PR TITLE
Try to avoid creating Stacks with no content when possible

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -271,6 +271,9 @@
   };
 
   function Context(stack, global, blocks, templateName) {
+    if(stack !== undefined && !(stack instanceof Stack)) {
+      stack = new Stack(stack);
+    }
     this.stack = stack;
     this.global = global;
     this.blocks = blocks;
@@ -278,7 +281,7 @@
   }
 
   dust.makeBase = function(global) {
-    return new Context(new Stack(), global);
+    return new Context(undefined, global);
   };
 
   /**
@@ -297,7 +300,7 @@
     if (context instanceof Context) {
       return context;
     }
-    return new Context(new Stack(context), {}, null, name);
+    return new Context(context, {}, null, name);
   };
 
   /**
@@ -358,10 +361,11 @@
           ctx = ctx.tail;
         }
 
+        // Try looking in the global context if we haven't found anything yet
         if (value !== undefined) {
           ctx = value;
         } else {
-          ctx = this.global ? this.global[first] : undefined;
+          ctx = this.global && this.global[first];
         }
       } else if (ctx) {
         // if scope is limited by a leading dot, don't search up the tree
@@ -408,7 +412,11 @@
   };
 
   Context.prototype.push = function(head, idx, len) {
-    return new Context(new Stack(head, this.stack, idx, len), this.global, this.blocks, this.getTemplateName());
+    if(head === undefined) {
+      dust.log("Not pushing an undefined variable onto the context", INFO);
+      return this;
+    }
+    return this.rebase(new Stack(head, this.stack, idx, len));
   };
 
   Context.prototype.pop = function() {
@@ -418,7 +426,7 @@
   };
 
   Context.prototype.rebase = function(head) {
-    return new Context(new Stack(head), this.global, this.blocks, this.getTemplateName());
+    return new Context(head, this.global, this.blocks, this.getTemplateName());
   };
 
   Context.prototype.clone = function() {

--- a/test/core.js
+++ b/test/core.js
@@ -1,6 +1,5 @@
-/*global dust*/
 (function(exports){
-
+/*global dust*/
 exports.coreSetup = function(suite, auto) {
   auto.forEach(function(test) {
     suite.test(test.name, function(){
@@ -10,9 +9,12 @@ exports.coreSetup = function(suite, auto) {
 
   suite.test("base context", function() {
     var base = dust.makeBase({
-      sayHello: function() { return "Hello!" }
+      sayHello: function() { return "Hello!"; }
     });
+    this.equals(base.push().push().push().push().stack, undefined);
     testRender(this, "{sayHello} {foo}", base.push({foo: "bar"}), "Hello! bar");
+    testRender(this, "{sayHello} {foo}", dust.makeBase().push({foo: "bar"}), " bar");
+    testRender(this, "{sayHello} {foo}", undefined, " ");
   });
 
   suite.test("valid keys", function() {
@@ -157,7 +159,7 @@ exports.coreSetup = function(suite, auto) {
       end: function () {
         unit.pass();
       }
-    })
+    });
   });
 
   suite.test("renderSource (multiple listeners)", function() {
@@ -183,7 +185,7 @@ exports.coreSetup = function(suite, auto) {
     });
   });
 
-}
+};
 
 function extend(target, donor) {
   donor = donor || {};

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -352,6 +352,34 @@ var coreTests = [
                   "<li>Thunder</li>\n" +
                   "</ul>",
         message: "should test the context"
+      },
+      {
+        name: "context push / pop",
+        source: "{#helper}{greeting} {firstName} {lastName}{.}{/helper}",
+        context: {"helper": function(chunk, context, bodies) {
+          var ctx = dust.makeBase({ greeting: "Hello" })
+                        .push({ firstName: "Dusty" })
+                        .push({ lastName: "Dusterson" })
+                        .push("!")
+                        .push(".");
+          ctx.pop();
+          return chunk.render(bodies.block, ctx);
+        }},
+        expected: "Hello Dusty Dusterson!",
+        message: "should allow pushing and popping a context"
+      },
+      {
+        name: "context clone",
+        source: "{#helper}{greeting} {firstName} {lastName}{/helper}",
+        context: {"helper": function(chunk, context, bodies) {
+          var ctx = dust.makeBase({ greeting: "Hello" })
+                        .push({ firstName: "Dusty" })
+                        .push({ lastName: "Dusterson" })
+                        .clone();
+          return chunk.render(bodies.block, ctx);
+        }},
+        expected: "Hello Dusty Dusterson",
+        message: "should allow cloning a context"
       }
     ]
   },


### PR DESCRIPTION
https://github.com/linkedin/dustjs-helpers/pull/128 showed that it's possible to get nasty Stacks that only contain `undefined` when you use `dust.makeBase`. As much as possible this behavior should be avoided.

Now the only way you can get one is if you explicitly push `undefined` onto a context stack... but then it's your own fault.

Context pop and clone exercise a lot of context creation behavior, and we didn't have tests for them yet anyways, so killing all the birds with one PR.