### PR TITLE
Resolve dynamic partial names via original context

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -337,7 +337,7 @@
     partial: function(context, node) {
       return '.p(' +
           compiler.compileNode(context, node[1]) +
-          ',' + compiler.compileNode(context, node[2]) +
+          ',ctx,' + compiler.compileNode(context, node[2]) +
           ',' + compiler.compileNode(context, node[3]) + ')';
     },
 

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -833,26 +833,26 @@
     return this;
   };
 
-  Chunk.prototype.partial = function(elem, context, params) {
+  Chunk.prototype.partial = function(elem, context, partialContext, params) {
     var head;
 
     if (!dust.isEmptyObject(params)) {
-      context = context.clone();
-      head = context.pop();
-      context = context.push(params)
-                       .push(head);
+      partialContext = partialContext.clone();
+      head = partialContext.pop();
+      partialContext = partialContext.push(params)
+                                     .push(head);
     }
 
     if (dust.isTemplateFn(elem)) {
       // The eventual result of evaluating `elem` is a partial name
       // Load the partial after getting its name and end the async chunk
       return this.capture(elem, context, function(name, chunk) {
-        context.templateName = name;
-        load(name, chunk, context).end();
+        partialContext.templateName = name;
+        load(name, chunk, partialContext).end();
       });
     } else {
-      context.templateName = elem;
-      return load(elem, this, context);
+      partialContext.templateName = elem;
+      return load(elem, this, partialContext);
     }
   };
 

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -1368,6 +1368,20 @@ var coreTests = [
         message: "should test partial with literal inline param and context. Fallback values for name or count are undefined"
       },
       {
+        name:     "partial with dynamic name and context",
+        source:   '{>"{partialName}":me /}',
+        context:  { partialName: "partial", me: { name: "Mick", count: 30 }},
+        expected: "Hello Mick! You have 30 new messages.",
+        message: "should test partial with dynamic name and a context"
+      },
+      {
+        name:     "partial with dynamic name and context and inline params",
+        source:   '{>"{partialName}" name=me.name count=me.count /}',
+        context:  { partialName: "partial", me: { name: "Mick", count: 30 }},
+        expected: "Hello Mick! You have 30 new messages.",
+        message: "should test partial with dynamic name and a context"
+      },
+      {
         name:     "partial with blocks and inline params",
         source:   '{>partial_with_blocks name=n count="{c}"/}',
         context:  { n: "Mick", c: 30 },
@@ -1462,8 +1476,8 @@ var coreTests = [
         source:   '{#helper template="partial"}{/helper}',
         context:  { "helper": function(chunk, context, bodies, params)
                     {
-                      var newContext = {};
-                      return chunk.partial(params.template, dust.makeBase(newContext));
+                      var newContext = dust.makeBase({});
+                      return chunk.partial(params.template, newContext, newContext, {});
                     }
                   },
         expected: "Hello ! You have  new messages.",


### PR DESCRIPTION
When scoping a partial with a dynamic name to a context like this:

    {>"{partial}":context /}

The evaluation of the partial name was done in `context` instead of the current scope.

Fixes #262
Closes #261