### PR TITLE
Preserve compiler backwards compatibility with pre-2.7 versions

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -844,6 +844,12 @@
   Chunk.prototype.partial = function(elem, context, partialContext, params) {
     var head;
 
+    if(params === undefined) {
+      // Compatibility for < 2.7.0 where `partialContext` did not exist
+      params = partialContext;
+      partialContext = context;
+    }
+
     if (!dust.isEmptyObject(params)) {
       partialContext = partialContext.clone();
       head = partialContext.pop();

--- a/test/jasmine-test/spec/coreTests.js
+++ b/test/jasmine-test/spec/coreTests.js
@@ -1374,6 +1374,18 @@ var coreTests = [
         message: "should test partial with dynamic name and a context"
       },
       {
+        name:     "backcompat (< 2.7.0) compiler with no partial context",
+        source:   '{#oldPartial/}',
+        context:  { "name": "Mick",
+                    "count": 30,
+                     oldPartial: function(chunk, context, bodies, params) {
+                        return chunk.partial("partial", context, params);
+                      }
+                  },
+        expected: "Hello Mick! You have 30 new messages.",
+        message:  "should preserve partials backwards compatibility with compilers pre-2.7"
+      },
+      {
         name:     "partial with blocks and inline params",
         source:   '{>partial_with_blocks name=n count="{c}"/}',
         context:  { n: "Mick", c: 30 },


### PR DESCRIPTION
This allows templates compiled with an older version of the compiler to continue working, even if using the 2.7 renderer.

Only templates with partials are affected.