### PR TITLE
Add a `cb(null, compiledTemplate)` signature to `dust.onLoad`

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -112,41 +112,79 @@
     return stream;
   };
 
+  /**
+   * Extracts a template function (body_0) from whatever is passed.
+   * @param nameOrTemplate {*} Could be:
+   *   - the name of a template to load from cache
+   *   - a CommonJS-compiled template (a function with a `template` property)
+   *   - a template function
+   * @param loadFromCache {Boolean} if false, don't look in the cache
+   * @return {Function} a template function, if found
+   */
+  function getTemplate(nameOrTemplate, loadFromCache/*=true*/) {
+    if(!nameOrTemplate) {
+      return;
+    }
+    if(typeof nameOrTemplate === 'function' && nameOrTemplate.template) {
+      // Sugar away CommonJS module templates
+      return nameOrTemplate.template;
+    }
+    if(dust.isTemplateFn(nameOrTemplate)) {
+      // Template functions passed directly
+      return nameOrTemplate;
+    }
+    if(loadFromCache !== false) {
+      // Try loading a template with this name from cache
+      return dust.cache[nameOrTemplate];
+    }
+  }
+
   function load(nameOrTemplate, chunk, context) {
     if(!nameOrTemplate) {
       return chunk.setError(new Error('No template or template name provided to render'));
     }
 
-    if(!dust.config.cache) {
+    if(dust.config.cache === false) {
       dust.cache = {};
     }
 
-    var tmpl;
-    if(typeof nameOrTemplate === 'function' && nameOrTemplate.template) {
-      // Sugar away CommonJS module templates
-      tmpl = nameOrTemplate.template;
-    } else if(dust.isTemplateFn(nameOrTemplate)) {
-      // Template functions passed directly
-      tmpl = nameOrTemplate;
-    } else {
-      // Load a template with this name from cache
-      tmpl = dust.cache[nameOrTemplate];
-    }
+    var template = getTemplate(nameOrTemplate);
 
-    if (tmpl) {
-      return tmpl(chunk, Context.wrap(context, tmpl.templateName));
+    if (template) {
+      return template(chunk, Context.wrap(context, template.templateName));
     } else {
       if (dust.onLoad) {
         return chunk.map(function(chunk) {
-          dust.onLoad(nameOrTemplate, function(err, src) {
+          // Alias just so it's easier to read that this would always be a name
+          var name = nameOrTemplate;
+          // Three possible scenarios for a successful callback:
+          //   - `require(nameOrTemplate)(dust); cb()`
+          //   - `src = readFile('src.dust'); cb(null, src)`
+          //   - `compiledTemplate = require(nameOrTemplate)(dust); cb(null, compiledTemplate)`
+          function done(err, srcOrTemplate) {
+            var template;
             if (err) {
               return chunk.setError(err);
             }
-            if (!dust.cache[nameOrTemplate]) {
-              dust.loadSource(dust.compile(src, nameOrTemplate));
+            // Prefer a template that is passed via callback over the cached version.
+            template = getTemplate(srcOrTemplate, false) || getTemplate(name);
+            if (!template) {
+              // It's a template string, compile it and register under `name`
+              if(dust.compile) {
+                dust.loadSource(dust.compile(srcOrTemplate, name));
+                template = dust.cache[name];
+              } else {
+                return chunk.setError(new Error('Dust compiler not available'));
+              }
             }
-            dust.cache[nameOrTemplate](chunk, Context.wrap(context, nameOrTemplate)).end();
-          });
+            template(chunk, Context.wrap(context, template.templateName)).end();
+          }
+
+          if(dust.onLoad.length === 3) {
+            dust.onLoad(name, context.options, done);
+          } else {
+            dust.onLoad(name, done);
+          }
         });
       }
       return chunk.setError(new Error('Template Not Found: ' + nameOrTemplate));
@@ -270,18 +308,19 @@
     }
   };
 
-  function Context(stack, global, blocks, templateName) {
+  function Context(stack, global, options, blocks, templateName) {
     if(stack !== undefined && !(stack instanceof Stack)) {
       stack = new Stack(stack);
     }
     this.stack = stack;
     this.global = global;
+    this.options = options;
     this.blocks = blocks;
     this.templateName = templateName;
   }
 
-  dust.makeBase = function(global) {
-    return new Context(undefined, global);
+  dust.makeBase = dust.context = function(global, options) {
+    return new Context(undefined, global, options);
   };
 
   /**
@@ -300,7 +339,7 @@
     if (context instanceof Context) {
       return context;
     }
-    return new Context(context, {}, null, name);
+    return new Context(context, {}, {}, null, name);
   };
 
   /**
@@ -426,7 +465,7 @@
   };
 
   Context.prototype.rebase = function(head) {
-    return new Context(head, this.global, this.blocks, this.getTemplateName());
+    return new Context(head, this.global, this.options, this.blocks, this.getTemplateName());
   };
 
   Context.prototype.clone = function() {
@@ -475,7 +514,7 @@
       } else {
         newBlocks = blocks.concat([locals]);
       }
-      return new Context(this.stack, this.global, newBlocks, this.getTemplateName());
+      return new Context(this.stack, this.global, this.options, newBlocks, this.getTemplateName());
     }
     return this;
   };

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -87,7 +87,9 @@
       return;
     }
     tmpl.templateName = name;
-    dust.cache[name] = tmpl;
+    if (dust.config.cache !== false) {
+      dust.cache[name] = tmpl;
+    }
   };
 
   dust.render = function(nameOrTemplate, context, callback) {
@@ -144,11 +146,7 @@
       return chunk.setError(new Error('No template or template name provided to render'));
     }
 
-    if(dust.config.cache === false) {
-      dust.cache = {};
-    }
-
-    var template = getTemplate(nameOrTemplate);
+    var template = getTemplate(nameOrTemplate, dust.config.cache);
 
     if (template) {
       return template(chunk, Context.wrap(context, template.templateName));
@@ -167,12 +165,11 @@
               return chunk.setError(err);
             }
             // Prefer a template that is passed via callback over the cached version.
-            template = getTemplate(srcOrTemplate, false) || getTemplate(name);
+            template = getTemplate(srcOrTemplate, false) || getTemplate(name, dust.config.cache);
             if (!template) {
               // It's a template string, compile it and register under `name`
               if(dust.compile) {
-                dust.loadSource(dust.compile(srcOrTemplate, name));
-                template = dust.cache[name];
+                template = dust.loadSource(dust.compile(srcOrTemplate, name));
               } else {
                 return chunk.setError(new Error('Dust compiler not available'));
               }

--- a/test/core.js
+++ b/test/core.js
@@ -110,13 +110,10 @@ exports.coreSetup = function(suite, auto) {
 
   suite.test("disable cache", function() {
     var unit = this,
-        template = "Version 1",
-        cache;
+        template = "Version 1";
     dust.onLoad = function(name, cb) {
       cb(null, template);
     };
-    // Store what's in the cache before we blow it all away
-    cache = dust.cache;
     dust.config.cache = false;
     dust.render("test", {}, function(err, out) {
       try {
@@ -128,9 +125,6 @@ exports.coreSetup = function(suite, auto) {
           } catch(err) {
             return unit.fail(err);
           } finally {
-            // restore
-            dust.cache = cache;
-            dust.onLoad = null;
             dust.config.cache = true;
           }
           unit.pass();

--- a/test/core.js
+++ b/test/core.js
@@ -17,19 +17,30 @@ exports.coreSetup = function(suite, auto) {
     testRender(this, "{sayHello} {foo}", undefined, " ");
   });
 
+  suite.test("context options", function() {
+    var opts = { lang: "fr" },
+        globals = { hello: "world" };
+    var base = dust.makeBase(globals, opts);
+    this.equals(base.options.lang, opts.lang);
+    base = base.rebase();
+    this.equals(base.options.lang, opts.lang);
+    this.pass();
+  });
+
   suite.test("valid keys", function() {
     testRender(this, "{_foo}{$bar}{baz1}", {_foo: 1, $bar: 2, baz1: 3}, "123");
   });
 
-  suite.test("onLoad callback", function() {
+  suite.test("onLoad that calls callback with source", function() {
     var unit = this;
+    dust.cache.onLoad = null;
     dust.onLoad = function(name, cb) {
-      cb(null, "Loaded: " + name);
+      cb(null, 'Loaded: ' + name + ', template name {templateName}');
     };
-    dust.render("onLoad", {}, function(err, out) {
+    dust.render("onLoad", { templateName: function(chunk, context) { return context.getTemplateName(); } }, function(err, out) {
       try {
         unit.ifError(err);
-        unit.equals(out, "Loaded: onLoad");
+        unit.equals(out, "Loaded: onLoad, template name onLoad");
       } catch(err) {
         unit.fail(err);
         return;
@@ -37,6 +48,66 @@ exports.coreSetup = function(suite, auto) {
       unit.pass();
     });
   });
+
+  suite.test('onLoad that returns a compiled template', function() {
+    var unit = this;
+    dust.cache.onLoad = null;
+    dust.onLoad = function(name, cb) {
+      var tmpl = dust.loadSource(dust.compile('Loaded: ' + name + ', template name {templateName}', 'foobar'));
+      cb(null, tmpl);
+    };
+    dust.render("onLoad", { templateName: function(chunk, context) { return context.getTemplateName(); } }, function(err, out) {
+      try {
+        unit.ifError(err);
+        unit.equals(out, "Loaded: onLoad, template name foobar");
+        unit.equals(dust.cache.onLoad, null);
+      } catch(err) {
+        unit.fail(err);
+        return;
+      }
+      unit.pass();
+    });
+  });
+
+  suite.test('onLoad that returns a compiled template; override template name', function() {
+    var unit = this;
+    dust.cache.onLoad = null;
+    dust.onLoad = function(name, cb) {
+      var tmpl = dust.loadSource(dust.compile('Loaded: ' + name + ', template name {templateName}', 'foobar'));
+      tmpl.templateName = 'override';
+      cb(null, dust.cache.foobar);
+    };
+    dust.render("onLoad", { templateName: function(chunk, context) { return context.getTemplateName(); } }, function(err, out) {
+      try {
+        unit.ifError(err);
+        unit.equals(out, "Loaded: onLoad, template name override");
+        unit.equals(dust.cache.onLoad, null);
+      } catch(err) {
+        unit.fail(err);
+        return;
+      }
+      unit.pass();
+    });
+  });
+
+  suite.test("onLoad receives context options", function() {
+    var unit = this;
+    dust.cache.onLoad = null;
+    dust.onLoad = function(name, opts, cb) {
+      cb(null, 'Loaded: ' + name + ', lang ' + opts.lang);
+    };
+    dust.render("onLoad", dust.makeBase(null, { lang: "fr" }), function(err, out) {
+      try {
+        unit.ifError(err);
+        unit.equals(out, "Loaded: onLoad, lang fr");
+      } catch(err) {
+        unit.fail(err);
+        return;
+      }
+      unit.pass();
+    });
+  });
+
   suite.test("disable cache", function() {
     var unit = this,
         template = "Version 1",

--- a/test/jasmine-test/spec/cjsSpec.js
+++ b/test/jasmine-test/spec/cjsSpec.js
@@ -16,6 +16,7 @@ describe('CommonJS template', function() {
 
   beforeEach(function() {
     tmpl = load(template);
+    dust.onLoad = undefined;
   });
 
   it('can be invoked to render', function() {
@@ -45,14 +46,30 @@ describe('CommonJS template', function() {
   });
 
   it('has a template property that can be passed to dust.render', function() {
-    expect(tmpl.template.templateName).toEqual(templateName);
     dust.render(tmpl.template, context, function(err, out) {
       expect(out).toEqual(rendered);
     });
   });
 
   it('has a name that can be passed to dust.render', function() {
-    dust.render(templateName, context, function(err, out) {
+    dust.render(tmpl.template.templateName, context, function(err, out) {
+      expect(out).toEqual(rendered);
+    });
+  });
+
+  it('can be passed to dust.render even if it is anonymous', function() {
+    tmpl = eval(dust.compile("Hello anonymous {world}!"))(dust);
+    dust.render(tmpl, context, function(err, out) {
+      expect(out).toEqual("Hello anonymous world!");
+    });
+  });
+
+  it('can be loaded via dust.onLoad', function() {
+    dust.onLoad = function(nameOrTemplate, callback) {
+      // Haha, you asked for some random template but we will always give you ours instead
+      callback(null, tmpl);
+    };
+    dust.render('foobar', context, function(err, out) {
       expect(out).toEqual(rendered);
     });
   });


### PR DESCRIPTION
Currently you can either call `cb()`, in which case Dust will try to load the original name from cache,
or `cb(null, src)`, and Dust will try to compile `src` and register it under the original name.

Sometimes, you might want to dynamically load one of several templates based on the original name.

This change adds `cb(null, compiledTemplate)` so you can load any template from cache or the filesystem,
register it manually (or not at all), and render it.

The returned template will NOT be registered under the original name.