### PR TITLE
Allow helpers to return primitives

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -298,7 +298,8 @@
         escape(node[1].text) +
         ',' + compiler.compileNode(context, node[2]) + ',' +
         compiler.compileNode(context, node[4]) + ',' +
-        compiler.compileNode(context, node[3]) +
+        compiler.compileNode(context, node[3]) + ',' +
+        compiler.compileNode(context, node[5]) +
         ')';
     },
 

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -272,13 +272,14 @@
     if (filters) {
       for (i = 0, len = filters.length; i < len; i++) {
         name = filters[i];
+        if (!name.length) {
+          continue;
+        }
         if (name === 's') {
           auto = null;
-        }
-        else if (typeof dust.filters[name] === 'function') {
+        } else if (typeof dust.filters[name] === 'function') {
           string = dust.filters[name](string);
-        }
-        else {
+        } else {
           dust.log('Invalid filter `' + name + '`', WARN);
         }
       }
@@ -780,6 +781,12 @@
       }
     }
 
+    if (dust.isEmptyObject(bodies)) {
+      // No bodies to render, and we've already invoked any function that was available in
+      // hopes of returning a Chunk.
+      return chunk;
+    }
+
     if (!dust.isEmptyObject(params)) {
       context = context.push(params);
     }
@@ -899,17 +906,33 @@
     }
   };
 
-  Chunk.prototype.helper = function(name, context, bodies, params) {
+  Chunk.prototype.helper = function(name, context, bodies, params, auto) {
     var chunk = this,
+        filters = params.filters,
         ret;
+
+    // Pre-2.7.1 compat: if auto is undefined, it's an old template. Automatically escape
+    if (auto === undefined) {
+      auto = 'h';
+    }
+
     // handle invalid helpers, similar to invalid filters
     if(dust.helpers[name]) {
       try {
         ret = dust.helpers[name](chunk, context, bodies, params);
-        if (dust.isThenable(ret)) {
-          return this.await(ret, context, bodies);
+        if (ret instanceof Chunk) {
+          return ret;
         }
-        return ret;
+        if(typeof filters === 'string') {
+          filters = filters.split('|');
+        }
+        if (!dust.isEmptyObject(bodies)) {
+          return chunk.section(ret, context, bodies, params);
+        }
+        // Helpers act slightly differently from functions in context in that they will act as
+        // a reference if they are self-closing (due to grammar limitations)
+        // In the Chunk.await function we check to make sure bodies is null before acting as a reference
+        return chunk.reference(ret, context, auto, filters);
       } catch(err) {
         dust.log('Error in helper `' + name + '`: ' + err.message, ERROR);
         return chunk.setError(err);
@@ -925,6 +948,8 @@
    * @param thenable {Thenable} the target thenable to await
    * @param context {Context} context to use to render the deferred chunk
    * @param bodies {Object} must contain a "body", may contain an "error"
+   * @param auto {String} automatically apply this filter if the Thenable is a reference
+   * @param filters {Array} apply these filters if the Thenable is a reference
    * @return {Chunk}
    */
   Chunk.prototype.await = function(thenable, context, bodies, auto, filters) {
@@ -932,16 +957,18 @@
         errorBody = bodies && bodies.error;
     return this.map(function(chunk) {
       thenable.then(function(data) {
-        if(body) {
-          chunk.render(body, context.push(data)).end();
-        } else {
-          chunk.reference(data, context, auto, filters).end();
+        if (body) {
+          chunk = chunk.render(body, context.push(data));
+        } else if(!bodies) {
+          // Actually a reference. Self-closing sections don't render
+          chunk = chunk.reference(data, context, auto, filters);
         }
+        chunk.end();
       }, function(err) {
         if(errorBody) {
           chunk.render(errorBody, context.push(err)).end();
         } else {
-          dust.log('Unhandled promise rejection in `' + context.getTemplateName() + '`');
+          dust.log('Unhandled promise rejection in `' + context.getTemplateName() + '`', INFO);
           chunk.end();
         }
       });
@@ -973,8 +1000,8 @@
             chunk = chunk.map(function(chunk) {
               chunk.render(body, context.push(thunk)).end();
             });
-          } else {
-            // Don't fork, just write into the master async chunk
+          } else if(!bodies) {
+            // When actually a reference, don't fork, just write into the master async chunk
             chunk = chunk.reference(thunk, context, auto, filters);
           }
         })
@@ -985,7 +1012,7 @@
           if(errorBody) {
             chunk.render(errorBody, context.push(err));
           } else {
-            dust.log('Unhandled stream error in `' + context.getTemplateName() + '`');
+            dust.log('Unhandled stream error in `' + context.getTemplateName() + '`', INFO);
           }
           if(!ended) {
             ended = true;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -64,13 +64,13 @@
         peg$c6 = void 0,
         peg$c7 = function(t, b, e, n) {
             e.push(["param", ["literal", "block"], b]);
-            t.push(e);
+            t.push(e, ["filters"]);
             return withPosition(t)
           },
         peg$c8 = "/",
         peg$c9 = { type: "literal", value: "/", description: "\"/\"" },
         peg$c10 = function(t) {
-            t.push(["bodies"]);
+            t.push(["bodies"], ["filters"]);
             return withPosition(t)
           },
         peg$c11 = /^[#?\^<+@%]/,

--- a/src/dust.pegjs
+++ b/src/dust.pegjs
@@ -40,13 +40,13 @@ section "section"
   }
   {
     e.push(["param", ["literal", "block"], b]);
-    t.push(e);
+    t.push(e, ["filters"]);
     return withPosition(t)
   }
   // self-closing format
   / t:sec_tag_start ws* "/" rd
   {
-    t.push(["bodies"]);
+    t.push(["bodies"], ["filters"]);
     return withPosition(t)
   }
 

--- a/test/helpers/template.helper.js
+++ b/test/helpers/template.helper.js
@@ -17,4 +17,11 @@
     }
     return defer.promise;
   };
+  dust.helpers.return = function(chunk, context, bodies, params) {
+    var val = params.value;
+    if(dust.isTemplateFn(val)) {
+      return val(chunk, context);
+    }
+    return val;
+  };
 }));


### PR DESCRIPTION
Previously returning a primitive would crash rendering with no way to recover.
Primitives are always HTML-escaped ~~with no way to turn that off~~ unless you override with a `filters` param. If you need to adjust the escaping, you need to return a Chunk and do the work yourself.

Closes #645