### PR TITLE
Fix array iteration when context is undefined

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -728,7 +728,7 @@
     var body = bodies.block,
         skip = bodies['else'],
         chunk = this,
-        i, len;
+        i, len, head;
 
     if (typeof elem === 'function' && !dust.isTemplateFn(elem)) {
       try {
@@ -757,23 +757,16 @@
       if (body) {
         len = elem.length;
         if (len > 0) {
-          // any custom helper can blow up the stack and store a flattened context, guard defensively
-          if(context.stack.head) {
-            context.stack.head.$len = len;
-          }
+          head = context.stack && context.stack.head || {};
+          head.$len = len;
           for (i = 0; i < len; i++) {
-            if(context.stack.head) {
-              context.stack.head.$idx = i;
-            }
+            head.$idx = i;
             chunk = body(chunk, context.push(elem[i], i, len));
           }
-          if(context.stack.head) {
-            context.stack.head.$idx = undefined;
-            context.stack.head.$len = undefined;
-          }
+          head.$idx = undefined;
+          head.$len = undefined;
           return chunk;
-        }
-        else if (skip) {
+        } else if (skip) {
           return skip(this, context);
         }
       }

--- a/test/core.js
+++ b/test/core.js
@@ -9,12 +9,14 @@ exports.coreSetup = function(suite, auto) {
 
   suite.test("base context", function() {
     var base = dust.makeBase({
-      sayHello: function() { return "Hello!"; }
+      sayHello: function() { return "Hello!"; },
+      names: ["Alice", "Bob", "Dusty"]
     });
     this.equals(base.push().push().push().push().stack, undefined);
     testRender(this, "{sayHello} {foo}", base.push({foo: "bar"}), "Hello! bar");
     testRender(this, "{sayHello} {foo}", dust.makeBase().push({foo: "bar"}), " bar");
     testRender(this, "{sayHello} {foo}", undefined, " ");
+    testRender(this, "{sayHello} {#names}{.} {/names}", base, "Hello! Alice Bob Dusty ");
   });
 
   suite.test("valid keys", function() {


### PR DESCRIPTION
Because we're manually manipulating the stack to add $idx and $len, we have to check here too and not just in Context#get

Closes #652