### PR TITLE
[discussion] Access the Context's index and length

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -353,12 +353,19 @@
    * @returns {string|object}
    */
   Context.prototype.get = function(path, cur) {
+    var first = path[0];
     if (typeof path === 'string') {
-      if (path[0] === '.') {
+      if (first === '.') {
         cur = true;
         path = path.substr(1);
       }
       path = path.split('.');
+    } else {
+      switch(first) {
+        case '$idx':
+        case '$len':
+          return this.stack && this.stack[first];
+      }
     }
     return this._get(cur, path);
   };
@@ -536,8 +543,13 @@
     this.tail = tail;
     this.isObject = head && typeof head === 'object';
     this.head = head;
-    this.index = idx;
-    this.of = len;
+
+    if(idx === undefined && len === undefined) {
+      idx = this.tail && this.tail.index;
+      len = this.tail && this.tail.of;
+    }
+    this.index = this.$idx = idx;
+    this.of = this.$len = len;
   }
 
   function Stub(callback) {
@@ -763,7 +775,7 @@
     var body = bodies.block,
         skip = bodies['else'],
         chunk = this,
-        i, len, head;
+        i, len;
 
     if (typeof elem === 'function' && !dust.isTemplateFn(elem)) {
       try {
@@ -792,14 +804,9 @@
       if (body) {
         len = elem.length;
         if (len > 0) {
-          head = context.stack && context.stack.head || {};
-          head.$len = len;
           for (i = 0; i < len; i++) {
-            head.$idx = i;
             chunk = body(chunk, context.push(elem[i], i, len));
           }
-          head.$idx = undefined;
-          head.$len = undefined;
           return chunk;
         } else if (skip) {
           return skip(this, context);


### PR DESCRIPTION
( instead of pushing our own copies onto the stack )

I think anything that manually manipulates the stack directly is a smell. We already have these properties available as `context.stack.index` and `context.stack.of`. It doesn't seem to make sense to directly reach into the stack's head and manually set them there.

Instead, we can short-circuit `get` in these cases.

This also has the side effect of not polluting someone's `context.current()` with something they didn't expect to be there.

I would just like to get some discussion on this one, I'm not convinced it's correct yet.
