### PR TITLE
If a Promise is resolved with an array, iterate over it instead of rendering the whole array at once.

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -953,18 +953,17 @@
    * @return {Chunk}
    */
   Chunk.prototype.await = function(thenable, context, bodies, auto, filters) {
-    var body = bodies && bodies.block,
-        errorBody = bodies && bodies.error;
     return this.map(function(chunk) {
       thenable.then(function(data) {
-        if (body) {
-          chunk = chunk.render(body, context.push(data));
-        } else if(!bodies) {
+        if (bodies) {
+          chunk = chunk.section(data, context, bodies);
+        } else {
           // Actually a reference. Self-closing sections don't render
           chunk = chunk.reference(data, context, auto, filters);
         }
         chunk.end();
       }, function(err) {
+        var errorBody = bodies && bodies.error;
         if(errorBody) {
           chunk.render(errorBody, context.push(err)).end();
         } else {

--- a/test/templates/all.js
+++ b/test/templates/all.js
@@ -887,6 +887,20 @@ return [
 		message: "should reserve an async section for a thenable"
 	  },
     {
+      name:   "thenable resolves with array into reference",
+      source: "{promise}",
+      context: { "promise": new FalsePromise(null, ['foo', 'bar', 'baz'])},
+      expected: 'foo,bar,baz',
+      message: "should iterate over an array resolved from a thenable"
+    },
+    {
+      name:   "thenable resolves with array into section",
+      source: "{#promise}{name}{/promise}",
+      context: { "promise": new FalsePromise(null, [{name: 'foo'}, {name: 'bar'}, {name: 'baz'}])},
+      expected: 'foobarbaz',
+      message: "should iterate over an array resolved from a thenable"
+    },
+    {
 		name:     "thenable empty section",
 		source:   "{#promise/}",
 		context:  { "promise": new FalsePromise(null, "magic") },


### PR DESCRIPTION
This was a missed case where section should have been used instead of render.

Closes #674 