### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "dustjs-linkedin",
-  "version": "2.7.2",
   "homepage": "https://github.com/linkedin/dustjs",
   "authors": [
     "Veena Basavaraj <vybs@users.noreply.github.com>",


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property