### PR TITLE
place location provided by peg 0.9 onto the AST

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -65,9 +65,7 @@
     path:      noop,
     literal:   noop,
     raw:       noop,
-    comment:   nullify,
-    line:      nullify,
-    col:       nullify
+    comment:   nullify
   };
 
   compiler.pragmas = {
@@ -106,7 +104,7 @@
         if (res[0] === 'buffer' || res[0] === 'format') {
           if (memo) {
             memo[0] = (res[0] === 'buffer') ? 'buffer' : memo[0];
-            memo[1] += res.slice(1, -2).join('');
+            memo[1] += res.slice(1).join('');
           } else {
             memo = res;
             out.push(res);
@@ -140,10 +138,10 @@
 
   function format(context, node) {
     if(dust.config.whitespace) {
-      // Format nodes are in the form ['format', eol, whitespace, line, col],
+      // Format nodes are in the form ['format', eol, whitespace],
       // which is unlike other nodes in that there are two pieces of content
       // Join eol and whitespace together to normalize the node format
-      node.splice(1, 2, node.slice(1, -2).join(''));
+      node.splice(1, 2, node.slice(1).join(''));
       return node;
     }
     return null;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -2719,7 +2719,8 @@
         return parseInt(arr.join(''), 10);
       }
       function withPosition(arr) {
-        return arr.concat([['line', location().start.line], ['col', location().start.column]]);
+        arr.location = location();
+        return arr;
       }
 
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -112,7 +112,7 @@
         peg$c40 = { type: "other", description: "identifier" },
         peg$c41 = function(p) {
             var arr = ["path"].concat(p);
-            arr.text = p[1].join('.').replace(/,line,\d+,col,\d+/g,'');
+            arr.text = p[1].join('.');
             return arr;
           },
         peg$c42 = function(k) {

--- a/src/dust.pegjs
+++ b/src/dust.pegjs
@@ -3,7 +3,8 @@
     return parseInt(arr.join(''), 10);
   }
   function withPosition(arr) {
-    return arr.concat([['line', location().start.line], ['col', location().start.column]]);
+    arr.location = location();
+    return arr;
   }
 }
 

--- a/src/dust.pegjs
+++ b/src/dust.pegjs
@@ -127,7 +127,7 @@ identifier "identifier"
   = p:path
   {
     var arr = ["path"].concat(p);
-    arr.text = p[1].join('.').replace(/,line,\d+,col,\d+/g,'');
+    arr.text = p[1].join('.');
     return arr;
   }
   / k:key


### PR DESCRIPTION
Since we are now using peg 0.9, it'll be useful to have the end line, end column and offset. Offset is useful for parser authors who want to splice on the file buffer (get the template text for a helper for instance).

Up for discussion:
* I'm dumping all of location into the location property of the peg node for max back compat. It's meta data so it seems cleaner.
* I'm removing the extra line/column from the ast so it's a breaking change