### PR TITLE
{?exists} and {^exists} now supports values from a promise

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -862,8 +862,16 @@
         skip = bodies['else'];
 
     if (dust.isThenable(elem)) {
-      return this.await(elem, context, bodies);
-    } 
+      return this.map(function(chunk) {
+        elem.then(function(data) {
+          chunk.exists(data, context, bodies).end();
+        }, function(err) {
+          dust.log('Unhandled promise rejection in `' + context.getTemplateName() + '`', INFO);
+          chunk.renderError(err, context, bodies).end();
+        });
+      });
+    }
+
     if (!dust.isEmpty(elem)) {
       if (body) {
         return body(this, context);
@@ -880,8 +888,16 @@
         skip = bodies['else'];
 
     if (dust.isThenable(elem)) {
-      return this.await(elem, context, bodies);
+      return this.map(function(chunk) {
+        elem.then(function(data) {
+          chunk.notexists(data, context, bodies).end();
+        }, function(err) {
+          dust.log('Unhandled promise rejection in `' + context.getTemplateName() + '`', INFO);
+          chunk.renderError(err, context, bodies).end();
+        });
+      });
     }
+
     if (dust.isEmpty(elem)) {
       if (body) {
         return body(this, context);
@@ -979,22 +995,31 @@
     return this.map(function(chunk) {
       thenable.then(function(data) {
         if (bodies) {
-          chunk = chunk.section(data, context, bodies);
+          chunk.section(data, context, bodies).end();
         } else {
           // Actually a reference. Self-closing sections don't render
-          chunk = chunk.reference(data, context, auto, filters);
+          chunk.reference(data, context, auto, filters).end();
         }
-        chunk.end();
       }, function(err) {
-        var errorBody = bodies && bodies.error;
-        if(errorBody) {
-          chunk.render(errorBody, context.push(err)).end();
-        } else {
-          dust.log('Unhandled promise rejection in `' + context.getTemplateName() + '`', INFO);
-          chunk.end();
-        }
+        dust.log('Unhandled promise rejection in `' + context.getTemplateName() + '`', INFO);
+        chunk.renderError(err, context, bodies).end();
       });
     });
+  };
+
+  /**
+   * Render an error body if available
+   * @param thenable {Thenable} the target thenable to await
+   * @param context {Context} context to use to render the error
+   * @param bodies {Object} may optionally contain an "error" which will be rendered
+   * @return {Chunk}
+   */
+  Chunk.prototype.renderError = function(err, context, bodies) {
+    var errorBody = bodies && bodies.error;
+    if (errorBody) {
+      return this.render(errorBody, context.push(err));
+    }
+    return this;
   };
 
   /**

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -1052,8 +1052,7 @@
    * @return {Chunk}
    */
   Chunk.prototype.stream = function(stream, context, bodies, auto, filters) {
-    var body = bodies && bodies.block,
-        errorBody = bodies && bodies.error;
+    var body = bodies && bodies.block;
     return this.map(function(chunk) {
       var ended = false;
       stream
@@ -1075,11 +1074,8 @@
           if(ended) {
             return;
           }
-          if(errorBody) {
-            chunk.render(errorBody, context.push(err));
-          } else {
-            dust.log('Unhandled stream error in `' + context.getTemplateName() + '`', INFO);
-          }
+          chunk.renderError(err, context, bodies);
+          dust.log('Unhandled stream error in `' + context.getTemplateName() + '`', INFO);
           if(!ended) {
             ended = true;
             chunk.end();

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -772,7 +772,7 @@
         asyncChunk.renderError(err, context, bodies).end();
       });
     });
-  };
+  }
 
   Chunk.prototype.tap = function(tap) {
     var taps = this.taps;

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -861,6 +861,9 @@
     var body = bodies.block,
         skip = bodies['else'];
 
+    if (dust.isThenable(elem)) {
+      return this.await(elem, context, bodies);
+    } 
     if (!dust.isEmpty(elem)) {
       if (body) {
         return body(this, context);
@@ -876,6 +879,9 @@
     var body = bodies.block,
         skip = bodies['else'];
 
+    if (dust.isThenable(elem)) {
+      return this.await(elem, context, bodies);
+    }
     if (dust.isEmpty(elem)) {
       if (body) {
         return body(this, context);

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -725,6 +725,11 @@
     return this;
   };
 
+  /**
+   * Inserts a new chunk that can be used to asynchronously render or write to it
+   * @param callback {Function} The function that will be called with the new chunk
+   * @returns {Chunk} A copy of this chunk instance in order to further chain function calls on the chunk
+   */
   Chunk.prototype.map = function(callback) {
     var cursor = new Chunk(this.root, this.next, this.taps),
         branch = new Chunk(this.root, cursor, this.taps);
@@ -738,6 +743,35 @@
       branch.setError(err);
     }
     return cursor;
+  };
+
+  /**
+   * Like Chunk#map but additionally resolves a thenable.  If the thenable succeeds the callback is invoked with
+   * a new chunk that can be used to asynchronously render or write to it, otherwise if the thenable is rejected 
+   * then the error body is rendered if available, an error is logged, and the callback is never invoked.
+   * @param {Chunk} The current chunk to insert a new chunk
+   * @param thenable {Thenable} the target thenable to await
+   * @param context {Context} context to use to render the deferred chunk
+   * @param bodies {Object} may optionally contain an "error" for when the thenable is rejected
+   * @param callback {Function} The function that will be called with the new chunk
+   * @returns {Chunk} A copy of this chunk instance in order to further chain function calls on the chunk
+   */
+  function mapThenable(chunk, thenable, context, bodies, callback) {
+    return chunk.map(function(asyncChunk) {
+      thenable.then(function(data) {
+        try {
+          callback(asyncChunk, data);
+        } catch (err) {
+          // handle errors the same way Chunk#map would.  This logic is only here since the thenable defers 
+          // logic such that the try / catch in Chunk#map would not capture it. 
+          dust.log(err, ERROR);
+          asyncChunk.setError(err);
+        }
+      }, function(err) {
+        dust.log('Unhandled promise rejection in `' + context.getTemplateName() + '`', INFO);
+        asyncChunk.renderError(err, context, bodies).end();
+      });
+    });
   };
 
   Chunk.prototype.tap = function(tap) {
@@ -862,13 +896,8 @@
         skip = bodies['else'];
 
     if (dust.isThenable(elem)) {
-      return this.map(function(chunk) {
-        elem.then(function(data) {
-          chunk.exists(data, context, bodies).end();
-        }, function(err) {
-          dust.log('Unhandled promise rejection in `' + context.getTemplateName() + '`', INFO);
-          chunk.renderError(err, context, bodies).end();
-        });
+      return mapThenable(this, elem, context, bodies, function(chunk, data){
+        chunk.exists(data, context, bodies).end();
       });
     }
 
@@ -888,13 +917,8 @@
         skip = bodies['else'];
 
     if (dust.isThenable(elem)) {
-      return this.map(function(chunk) {
-        elem.then(function(data) {
-          chunk.notexists(data, context, bodies).end();
-        }, function(err) {
-          dust.log('Unhandled promise rejection in `' + context.getTemplateName() + '`', INFO);
-          chunk.renderError(err, context, bodies).end();
-        });
+      return mapThenable(this, elem, context, bodies, function(chunk, data){
+        chunk.notexists(data, context, bodies).end();
       });
     }
 
@@ -992,24 +1016,19 @@
    * @return {Chunk}
    */
   Chunk.prototype.await = function(thenable, context, bodies, auto, filters) {
-    return this.map(function(chunk) {
-      thenable.then(function(data) {
-        if (bodies) {
-          chunk.section(data, context, bodies).end();
-        } else {
-          // Actually a reference. Self-closing sections don't render
-          chunk.reference(data, context, auto, filters).end();
-        }
-      }, function(err) {
-        dust.log('Unhandled promise rejection in `' + context.getTemplateName() + '`', INFO);
-        chunk.renderError(err, context, bodies).end();
-      });
+    return mapThenable(this, thenable, context, bodies, function(chunk, data){
+      if (bodies) {
+        chunk.section(data, context, bodies).end();
+      } else {
+        // Actually a reference. Self-closing sections don't render
+        chunk.reference(data, context, auto, filters).end();
+      }
     });
   };
 
   /**
    * Render an error body if available
-   * @param thenable {Thenable} the target thenable to await
+   * @param err {Error} error that occurred
    * @param context {Context} context to use to render the error
    * @param bodies {Object} may optionally contain an "error" which will be rendered
    * @return {Chunk}

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -896,7 +896,7 @@
         skip = bodies['else'];
 
     if (dust.isThenable(elem)) {
-      return mapThenable(this, elem, context, bodies, function(chunk, data){
+      return mapThenable(this, elem, context, bodies, function(chunk, data) {
         chunk.exists(data, context, bodies).end();
       });
     }
@@ -917,7 +917,7 @@
         skip = bodies['else'];
 
     if (dust.isThenable(elem)) {
-      return mapThenable(this, elem, context, bodies, function(chunk, data){
+      return mapThenable(this, elem, context, bodies, function(chunk, data) {
         chunk.notexists(data, context, bodies).end();
       });
     }
@@ -1016,7 +1016,7 @@
    * @return {Chunk}
    */
   Chunk.prototype.await = function(thenable, context, bodies, auto, filters) {
-    return mapThenable(this, thenable, context, bodies, function(chunk, data){
+    return mapThenable(this, thenable, context, bodies, function(chunk, data) {
       if (bodies) {
         chunk.section(data, context, bodies).end();
       } else {

--- a/test/templates.spec.js
+++ b/test/templates.spec.js
@@ -93,7 +93,7 @@ function render(test, dust) {
         expect(messageInLog(dust.logQueue, test.log)).toEqual(true);
       }
       if (typeof test.expected !== 'undefined') {
-        expect(test.expected).toEqual(output);
+        expect(output).toEqual(test.expected);
       }
       done();
     };
@@ -124,7 +124,7 @@ function stream(test, dust) {
         expect(messageInLog(dust.logQueue, test.log)).toEqual(true);
       }
       if (typeof test.expected !== 'undefined') {
-        expect(test.expected).toEqual(result.output);
+        expect(result.output).toEqual(test.expected);
       }
       done();
     };
@@ -196,7 +196,7 @@ function pipe(test, dust) {
         expect(messageInLog(dust.logQueue, test.log)).toEqual(true);
       }
       if (typeof test.expected !== 'undefined') {
-        expect(test.expected).toEqual(result.data);
+        expect(result.data).toEqual(test.expected);
       }
       if(calls === 2) {
         done();

--- a/test/templates/all.js
+++ b/test/templates/all.js
@@ -585,6 +585,13 @@ return [
         message:  "empty array is treated as empty in exists"
       },
       {
+        name:     "empty array resolved from a Promise is treated as empty in exists",
+        source:   "{?emptyArrayFromPromise}true{:else}false{/emptyArrayFromPromise}",
+        context:   {"emptyArrayFromPromise": Promise.resolve([])},
+        expected: "false",
+        message:  "empty array resolved from a Promise is treated as empty in exists"
+      },
+      {
         name:     "empty {} is treated as non empty in exists",
         source:   "{?object}true{:else}false{/object}",
         context:  {"object": {}},

--- a/test/templates/all.js
+++ b/test/templates/all.js
@@ -263,6 +263,18 @@ return [
 
       },
       {
+        name:     "{?exists} supports promises and uses correct context",
+        source:   "{#a}{?b}{test}{/b}{/a}",
+        context:  {
+          a: {
+            b: FalsePromise(null, { test: "BAD" }),
+            test: "GOOD"
+          }
+        },
+        expected: "GOOD",
+        message:  "{?exists} supports promises and uses correct context",      
+      },
+      {
         name:     "issue322 use base template picks up prefix chunk data",
         source:   '{>issue322 name="abc"/}' +
 		   "{<abc}ABC{/abc}",
@@ -587,7 +599,7 @@ return [
       {
         name:     "empty array resolved from a Promise is treated as empty in exists",
         source:   "{?emptyArrayFromPromise}true{:else}false{/emptyArrayFromPromise}",
-        context:   {"emptyArrayFromPromise": Promise.resolve([])},
+        context:   {"emptyArrayFromPromise": FalsePromise(null, [])},
         expected: "false",
         message:  "empty array resolved from a Promise is treated as empty in exists"
       },


### PR DESCRIPTION
I logged this as bug #752 - {?exists/} behavior different when using promises.