### PR TITLE
Decrease security vulnerabilities by upgrading cli dependency (#754 #748)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "chokidar": "~1.5.1",
-    "cli": "~0.11.2"
+    "cli": "^1.0.1"
   },
   "devDependencies": {
     "ayepromise": "~1.1.1",


### PR DESCRIPTION
Looks like the `cli` project didn't change their interface so no changes are needed with *dustjs*. This should resolve the `nsp` security alert and make *dustjs* secure.

Please merge and publish to npm, thanks

-=Dan=-