### PR TITLE
Change chokidar dep to caret

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "linkedin"
   ],
   "dependencies": {
-    "chokidar": "~1.5.1",
+    "chokidar": "^1.6.1",
     "cli": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The small part of the API that is used would bump the major version digit.

The tilde was probably copied from the previous dependency: https://github.com/linkedin/dustjs/commit/f77eb2ea2789c7a4796e34b4887b05784198417d

Since then, chokidar has not changed it's API. I think it is safe to use the caret now.

The upgrade to 1.6 enables the use of the environment variable `CHOKIDAR_USEPOLLING`, which will make the watcher work even on networked filesystems.