### PR TITLE
#733 remove confusing debug message when blocks are not in context

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -504,20 +504,17 @@
 
     blocks = this.blocks;
 
-    if (!blocks) {
-      dust.log('No blocks for context `' + key + '` in template `' + this.getTemplateName() + '`', DEBUG);
-      return false;
-    }
-
-    len = blocks.length;
-    while (len--) {
-      fn = blocks[len][key];
-      if (fn) {
-        return fn;
+    if (blocks) {
+      len = blocks.length;
+      while (len--) {
+        fn = blocks[len][key];
+        if (fn) {
+          return fn;
+        }
       }
     }
 
-    dust.log('Malformed template `' + this.getTemplateName() + '` was missing one or more blocks.');
+    dust.log('Block `' + key + '` in template `' + this.getTemplateName() + '` was not found', DEBUG);
     return false;
   };
 


### PR DESCRIPTION
see discussion in #733. There's no reason to indicate this is a malformed template.