### PR TITLE
#755 return templateName when exiting a partial

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -945,6 +945,7 @@
   Chunk.prototype.partial = function(elem, context, partialContext, params) {
     var head;
 
+    var prevTemplateName = context.getTemplateName();
     if(params === undefined) {
       // Compatibility for < 2.7.0 where `partialContext` did not exist
       params = partialContext;
@@ -963,9 +964,12 @@
       // Load the partial after getting its name and end the async chunk
       return this.capture(elem, context, function(name, chunk) {
         load(name, chunk, partialContext).end();
+        context.templateName = prevTemplateName;
       });
     } else {
-      return load(elem, this, partialContext);
+      var o = load(elem, this, partialContext);
+      context.templateName = prevTemplateName;
+      return o;
     }
   };
 


### PR DESCRIPTION
OH THE HORROR! Throwing this up to move the conversation around #755 

there is likely a better way to do this. 