### PR TITLE
Dustjs:Removed PhantomJS Dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "5"
-  - "6"
+  - "8"
+  - "9"
+  - "10"
 matrix:
   include:
-    - node_js: "0.10"
+    - node_js: "11"
       env:
         - TEST="all"
         - CXX=g++-4.8

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -206,7 +206,7 @@ module.exports = function(grunt) {
       },
       lib_test: {
         files: ['<%= jshint.libs.src %>', '<%= jasmine.options.specs %>'],
-        tasks: ['testPhantom']
+        tasks: ['testChrome']
       }
     },
     bump: {
@@ -287,7 +287,7 @@ module.exports = function(grunt) {
   //test tasks
   grunt.registerTask('testNode',       ['jasmine_nodejs:templates', 'jasmine_nodejs:core', 'jasmine_nodejs:cjs']);
   grunt.registerTask('testRhino',      ['build', 'execute:testRhino']);
-  grunt.registerTask('testPhantom',    ['build', 'jasmine:testProd']);
+  grunt.registerTask('testChrome',     ['build', 'jasmine:testProd']);
   grunt.registerTask('testCli',        ['jasmine_nodejs:dustc']);
   grunt.registerTask('test',           ['build', 'jasmine:testProd', 'testCli', 'testNode', 'execute:testRhino', 'jasmine:coverage']);
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "grunt-contrib-concat": "~1.0.1",
     "grunt-contrib-connect": "~1.0.2",
     "grunt-contrib-copy": "~1.0.0",
-    "grunt-contrib-jasmine": "~1.0.3",
+    "grunt-contrib-jasmine": "~2.0.3",
     "grunt-contrib-jshint": "~1.0.0",
     "grunt-contrib-uglify": "~1.0.1",
     "grunt-contrib-watch": "~1.0.0",


### PR DESCRIPTION
PhantomJS is an unmaintained project, removed phantomjs support from package.json, updated the grunt-contrib-jasmine version to 2.0.3 as it supports puppeteer instead of phantomjs.

Updated the Gruntfile.js for adding the chrome support in it, Also updated the travis.yml to use the latest node version for the testing as the earlier versions used were very old.